### PR TITLE
docs: add /// to major components and strip noise comments

### DIFF
--- a/app/src/application/network/presence/interface.rs
+++ b/app/src/application/network/presence/interface.rs
@@ -2,17 +2,34 @@ use std::net::IpAddr;
 use tokio::io;
 use uuid::Uuid;
 
+/// Port for peer discovery and liveness announcements.
+///
+/// `advertise` publishes this instance on the local network;
+/// `next` blocks for the next observed peer event; `shutdown`
+/// retracts the advertisement before the process exits so peers
+/// learn of the disconnect immediately rather than waiting for a
+/// timeout.
+///
+/// The production adapter is `MdnsAdapter`.
 pub trait PresenceInterface {
+    /// Starts announcing this instance to peers.
     async fn advertise(&self) -> io::Result<()>;
+    /// Awaits the next presence event from the network. `None` means
+    /// the underlying stream has terminated.
     async fn next(&self) -> io::Result<Option<PresenceEvent>>;
+    /// Retracts the advertisement and stops the underlying service.
     async fn shutdown(&self);
 }
 
+/// Discovery-layer event delivered by `PresenceInterface::next`.
 pub enum PresenceEvent {
+    /// A peer announced itself (or reconfirmed liveness). A change in
+    /// `instance_id` for the same `id` indicates the peer restarted.
     Ping {
         id: Uuid,
         addr: IpAddr,
         instance_id: Uuid,
     },
+    /// A peer explicitly retracted its advertisement.
     Disconnect(Uuid),
 }

--- a/app/src/application/network/presence/service.rs
+++ b/app/src/application/network/presence/service.rs
@@ -11,6 +11,13 @@ use tokio::{io, sync::mpsc::Sender};
 use tracing::{trace, warn};
 use uuid::Uuid;
 
+/// Application service that turns `PresenceEvent`s from the discovery
+/// adapter into peer-manager updates and outbound handshakes.
+///
+/// New pings trigger a `HandshakeSyn`; disconnects evict the peer
+/// from the manager. The service also calls `shutdown` on the adapter
+/// during graceful shutdown so peers see the retraction before the
+/// presence advert times out.
 pub struct PresenceService<P: PresenceInterface> {
     adapter: P,
     state: Arc<AppState>,
@@ -33,6 +40,8 @@ impl<P: PresenceInterface> PresenceService<P> {
         }
     }
 
+    /// Advertises this instance and drives the event loop until the
+    /// adapter's stream terminates.
     pub async fn run(&self) -> io::Result<()> {
         self.adapter.advertise().await?;
 

--- a/app/src/application/network/transport/interface.rs
+++ b/app/src/application/network/transport/interface.rs
@@ -2,14 +2,32 @@ use crate::domain::{TransportData, TransportEvent};
 use std::net::IpAddr;
 use tokio::io::{self};
 
+/// Port for the peer-to-peer transport that carries handshakes,
+/// metadata, requests, and entry transfers.
+///
+/// Implementations are bidirectional: `recv` blocks until the next
+/// inbound `TransportEvent` is available; `send` delivers a
+/// `TransportData` payload to a specific peer by address. The
+/// production adapter is `TcpAdapter`.
+///
+/// `recv` errors after a connection is accepted are treated as bad
+/// peer messages by the caller and the loop continues — a corrupt
+/// transfer must not stop the synchronizer. Listener bind/accept
+/// failures, by contrast, are fatal.
 pub trait TransportInterface {
+    /// Awaits the next inbound transport event.
     async fn recv(&self) -> TransportResult<TransportEvent>;
 
+    /// Sends `data` to `target`. Returns once the payload has been
+    /// written to the wire.
     async fn send(&self, target: IpAddr, data: TransportData) -> TransportResult<()>;
 }
 
+/// Result alias for fallible transport calls.
 pub type TransportResult<T> = Result<T, TransportError>;
 
+/// Error returned by `TransportInterface` implementors. A single
+/// opaque variant — see `PersistenceError` for the same rationale.
 pub enum TransportError {
     Failure(String),
 }

--- a/app/src/application/network/transport/receiver.rs
+++ b/app/src/application/network/transport/receiver.rs
@@ -14,6 +14,14 @@ use std::{net::IpAddr, sync::Arc};
 use tokio::{fs, io, sync::mpsc::Sender};
 use tracing::{error, info, warn};
 
+/// Inbound side of the transport service.
+///
+/// Pulls events off the adapter and dispatches them onto two internal
+/// queues — `control_chan` for handshake/metadata/request messages
+/// and `transfer_chan` for entry bytes — so a slow file write cannot
+/// starve protocol traffic. Handlers reconcile peer state, persist
+/// metadata, and either accept, write, or conflict-resolve incoming
+/// entries before re-broadcasting.
 pub struct TransportReceiver<T: TransportInterface, P: PersistenceInterface> {
     adapter: Arc<T>,
     state: Arc<AppState>,

--- a/app/src/application/network/transport/sender.rs
+++ b/app/src/application/network/transport/sender.rs
@@ -14,6 +14,12 @@ use tokio::{
 };
 use tracing::{error, warn};
 
+/// Outbound side of the transport service.
+///
+/// Reads `TransportChannelData` items off the shared outbound channel
+/// and splits them across two priority lanes — `control_chan` for
+/// handshakes/metadata/requests, `transfer_chan` for bulk entry
+/// transfers — so the latter cannot delay protocol messages.
 pub struct TransportSender<T: TransportInterface, P: PersistenceInterface> {
     adapter: Arc<T>,
     state: Arc<AppState>,

--- a/app/src/application/network/transport/service.rs
+++ b/app/src/application/network/transport/service.rs
@@ -11,6 +11,12 @@ use crate::{
 use std::sync::Arc;
 use tokio::{io, sync::mpsc::Sender};
 
+/// Pairs a `TransportSender` and `TransportReceiver` over the same
+/// adapter, running them concurrently.
+///
+/// `new` returns the service together with the sender side of the
+/// outbound channel so other subsystems (file watcher, presence) can
+/// enqueue messages without holding a reference to the service.
 pub struct TransportService<T: TransportInterface, P: PersistenceInterface> {
     sender: TransportSender<T, P>,
     receiver: TransportReceiver<T, P>,

--- a/app/src/application/persistence/interface.rs
+++ b/app/src/application/persistence/interface.rs
@@ -2,16 +2,38 @@ use tokio::io;
 
 use crate::domain::EntryInfo;
 
+/// Port for entry-metadata persistence.
+///
+/// Implementations store and retrieve `EntryInfo` keyed by their
+/// `RelativePath` string. The interface is intentionally small —
+/// callers never query or mutate version vectors directly; they
+/// `insert_or_replace_entry` after merging in memory.
+///
+/// All methods are `async` because the default adapter (`SqliteDb`)
+/// goes over a real I/O boundary; implementations must be safe to call
+/// concurrently from multiple tasks.
 #[async_trait::async_trait]
 pub trait PersistenceInterface: Send + Sync + 'static {
+    /// Inserts a new entry or replaces an existing one with the same name.
     async fn insert_or_replace_entry(&self, entry: &EntryInfo) -> PersistenceResult<()>;
+    /// Looks up an entry by its relative-path name, returning `None`
+    /// if absent.
     async fn get_entry(&self, name: &str) -> PersistenceResult<Option<EntryInfo>>;
+    /// Returns every persisted entry. Used at startup to rehydrate the
+    /// in-memory view.
     async fn list_all_entries(&self) -> PersistenceResult<Vec<EntryInfo>>;
+    /// Deletes an entry by name. Deleting a missing entry must not error.
     async fn delete_entry(&self, name: &str) -> PersistenceResult<()>;
 }
 
+/// Result alias for fallible persistence calls.
 pub type PersistenceResult<T> = Result<T, PersistenceError>;
 
+/// Error returned by `PersistenceInterface` implementors.
+///
+/// Currently a single opaque variant — error categorization is the
+/// adapter's responsibility, and the surrounding `io::Error` produced
+/// by the `From` impl is what callers actually propagate.
 #[derive(Debug)]
 pub enum PersistenceError {
     Failure(String),

--- a/app/src/application/state/app_state.rs
+++ b/app/src/application/state/app_state.rs
@@ -16,6 +16,9 @@ pub const DEFAULT_HTTP_PORT: u16 = 42880;
 pub const DEFAULT_PRESENCE_PORT: u16 = 42881;
 pub const DEFAULT_TRANSPORT_PORT: u16 = 42882;
 
+/// Returns the production port assignment. Tests inject their own
+/// `AppPorts { http: 0, ... }` to avoid collisions with a running
+/// instance and with each other.
 pub fn default_ports() -> AppPorts {
     AppPorts {
         http: DEFAULT_HTTP_PORT,
@@ -24,6 +27,17 @@ pub fn default_ports() -> AppPorts {
     }
 }
 
+/// Process-wide runtime hub shared as `Arc<AppState>` across every
+/// subsystem.
+///
+/// Holds the device's identities (`local_id` persists across
+/// restarts; `instance_id` is regenerated per process), the active
+/// `home_path` and port assignments, the live peer and sync-dir maps,
+/// and the SSE broadcast channel used to push events to the GUI.
+///
+/// All on-disk paths are resolved through the injected `SyncheDirs`
+/// rather than global statics — see `CLAUDE.md` (Runtime / data
+/// files) for why tests depend on per-test isolation here.
 pub struct AppState {
     dirs: SyncheDirs,
     ports: AppPorts,
@@ -128,6 +142,9 @@ impl AppState {
         Ok((local_id, Uuid::new_v4()))
     }
 
+    /// Adds `name` to `config.toml` and the in-memory `sync_dirs`
+    /// map. Returns `Ok(false)` if the directory was already present
+    /// (idempotent, no rewrite).
     pub async fn add_dir_to_config(&self, name: &RelativePath) -> io::Result<bool> {
         let mut directory: Vec<ConfigDirectory> = {
             let dirs = self.sync_dirs.read().await;
@@ -151,6 +168,8 @@ impl AppState {
         .map(|_| true)
     }
 
+    /// Removes `name` from `config.toml`. No-op if the directory was
+    /// not configured.
     pub async fn remove_dir_from_config(&self, name: &RelativePath) -> io::Result<()> {
         let directory: Vec<ConfigDirectory> = {
             let dirs = self.sync_dirs.read().await;
@@ -172,6 +191,10 @@ impl AppState {
         .await
     }
 
+    /// Validates `new_path` and rewrites `config.toml` with it. The
+    /// running synchronizer observes the change through its config
+    /// watcher and triggers the `HOME_PATH_CHANGED:` restart loop in
+    /// `Synchronizer::run_default_with_restart`.
     pub async fn set_home_path_in_config(&self, new_path: String) -> io::Result<()> {
         let new_home_path = self.validate_home_path(&new_path).await?;
 
@@ -191,6 +214,9 @@ impl AppState {
         .await
     }
 
+    /// Canonicalizes `path_str`, creating the directory (and parents)
+    /// if it does not exist. Errors if the path exists but is not a
+    /// directory.
     pub async fn validate_home_path(&self, path_str: &str) -> io::Result<CanonicalPath> {
         let path_buf = PathBuf::from(path_str);
 
@@ -211,10 +237,15 @@ impl AppState {
         fs::write(self.dirs.config_file(), contents).await
     }
 
+    /// Returns `true` if `name` is an exact match for a configured
+    /// sync directory.
     pub async fn contains_sync_dir(&self, name: &RelativePath) -> bool {
         self.sync_dirs.read().await.contains_key(name)
     }
 
+    /// Returns `true` if `path` falls under any configured sync
+    /// directory — the boundary check that decides whether a watcher
+    /// event is relevant.
     pub async fn is_under_sync_dir(&self, path: &RelativePath) -> bool {
         let dirs = self.sync_dirs.read().await;
         dirs.keys().any(|d| path.starts_with(&**d))

--- a/app/src/application/state/entry_manager.rs
+++ b/app/src/application/state/entry_manager.rs
@@ -20,6 +20,14 @@ use tracing::{trace, warn};
 use uuid::Uuid;
 use walkdir::WalkDir;
 
+/// Owns the lifecycle of synchronized filesystem entries.
+///
+/// Combines a `PersistenceInterface` (durable metadata store), the
+/// shared `AppState` (sync directories, home path, device id), and an
+/// `IgnoreHandler` (`.gitignore` rules) to scan the home directory at
+/// startup, react to local file events, and reconcile metadata that
+/// arrives from peers — including materializing conflict files when
+/// `VersionCmp::Conflict` is detected.
 pub struct EntryManager<P: PersistenceInterface> {
     db: P,
     state: Arc<AppState>,
@@ -35,6 +43,10 @@ impl<P: PersistenceInterface> EntryManager<P> {
         })
     }
 
+    /// Scans every configured sync directory, then reconciles the
+    /// on-disk view with the persisted entries — creating missing
+    /// directories, hashing files, and seeding version vectors for
+    /// fresh entries. Called once at startup.
     pub async fn init(&self) -> io::Result<()> {
         let mut filesystem_entries = HashMap::new();
 
@@ -243,6 +255,10 @@ impl<P: PersistenceInterface> EntryManager<P> {
         Ok(entry)
     }
 
+    /// Given a peer's full entry map (typically delivered in a
+    /// handshake), returns the subset that we should request from
+    /// them — entries we don't have, or entries where the peer's
+    /// version dominates ours after conflict resolution.
     pub async fn get_entries_to_request(
         &self,
         peer: &Peer,
@@ -275,6 +291,11 @@ impl<P: PersistenceInterface> EntryManager<P> {
         Ok(to_request)
     }
 
+    /// Compares the local and peer copies of an entry and, if the
+    /// result is `Conflict`, defers to `handle_conflict` to decide a
+    /// winner (and possibly write a conflict file). When the local
+    /// side wins or both sides agree, also merges the peer's version
+    /// counters into the local entry so future comparisons converge.
     #[tracing::instrument(skip_all, fields(entry = %local_entry.name, peer = %peer_id))]
     pub async fn compare_and_resolve_conflict(
         &self,
@@ -298,6 +319,13 @@ impl<P: PersistenceInterface> EntryManager<P> {
         Ok(cmp)
     }
 
+    /// Resolves a true concurrent-edit conflict.
+    ///
+    /// Removal-vs-live takes a fixed tiebreak (the live side wins);
+    /// otherwise the lower `local_id` wins to give a deterministic,
+    /// peer-agnostic choice. If the local side must give way, the
+    /// existing file is copied to `<stem>_CONFLICT_<unix>_<id>.<ext>`
+    /// so no user data is lost before the peer's version is adopted.
     #[tracing::instrument(skip_all, fields(entry = %local_entry.name, peer = %peer_id))]
     pub async fn handle_conflict(
         &self,
@@ -354,6 +382,10 @@ impl<P: PersistenceInterface> EntryManager<P> {
         Ok(VersionCmp::KeepOther)
     }
 
+    /// Reconciles a single inbound metadata message: drops it if the
+    /// path is excluded, requests/keeps based on
+    /// `compare_and_resolve_conflict` if the entry exists locally, or
+    /// declares the remote version the winner if we've never seen it.
     pub async fn handle_metadata(
         &self,
         peer_id: Uuid,

--- a/app/src/application/state/ignore.rs
+++ b/app/src/application/state/ignore.rs
@@ -7,6 +7,13 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
+/// Maintains per-directory `.gitignore` rules so the entry manager
+/// can skip files the user does not want synchronized.
+///
+/// Keyed by the relative directory that owns each `.gitignore`;
+/// `is_ignored` walks the prefix chain of a path so a deeper
+/// `.gitignore` can layer on top of a parent one (matching git's own
+/// semantics).
 pub struct IgnoreHandler {
     state: Arc<AppState>,
     gis: RwLock<HashMap<String, Gitignore>>,
@@ -20,6 +27,9 @@ impl IgnoreHandler {
         }
     }
 
+    /// Parses a `.gitignore` and registers it under the directory
+    /// that contains it. A subsequent insert for the same key
+    /// replaces the previous rules, providing live edits.
     pub async fn insert_gitignore(&self, gitignore_path: &CanonicalPath) {
         let (gi, err) = Gitignore::new(gitignore_path);
 
@@ -39,6 +49,8 @@ impl IgnoreHandler {
         }
     }
 
+    /// Returns `true` if any registered `.gitignore` (at `relative`
+    /// or any ancestor) matches `path`.
     pub async fn is_ignored(&self, path: &CanonicalPath, relative: &RelativePath) -> bool {
         let gis = self.gis.read().await;
         if gis.is_empty() {
@@ -52,7 +64,6 @@ impl IgnoreHandler {
         let mut parts = relative.split('/').peekable();
         while let Some(part) = parts.next() {
             if parts.peek().is_none() {
-                // skip last/self path
                 break;
             }
 
@@ -70,6 +81,8 @@ impl IgnoreHandler {
         false
     }
 
+    /// Drops the rules registered for the directory containing
+    /// `relative` (which must end in `/.gitignore`).
     pub async fn remove_gitignore(&self, relative: &RelativePath) {
         if let Some(key) = relative.strip_suffix("/.gitignore") {
             self.gis.write().await.remove(key);

--- a/app/src/application/state/peer_manager.rs
+++ b/app/src/application/state/peer_manager.rs
@@ -5,6 +5,8 @@ use tokio::sync::broadcast;
 use tracing::info;
 use uuid::Uuid;
 
+/// Coordinates the live peer map on `AppState` and emits
+/// `ServerEvent`s to the GUI when peers come and go.
 pub struct PeerManager {
     state: Arc<AppState>,
     sse_tx: broadcast::Sender<ServerEvent>,
@@ -18,6 +20,9 @@ impl PeerManager {
         })
     }
 
+    /// Inserts or refreshes a peer. Emits `PeerConnected` only on the
+    /// first appearance for a given `(id, instance_id)` pair, so a
+    /// peer restart fires a fresh event while plain re-pings do not.
     #[tracing::instrument(skip_all, fields(peer = %peer.id, addr = %peer.addr))]
     pub async fn insert(&self, peer: Peer) {
         if !self.seen(&peer.id, &peer.instance_id).await {
@@ -33,6 +38,8 @@ impl PeerManager {
         self.state.peers.write().await.insert(peer.id, peer);
     }
 
+    /// Returns `true` if the manager already knows `id` and its
+    /// `instance_id` matches — i.e. the peer has not restarted.
     pub async fn seen(&self, id: &Uuid, instance_id: &Uuid) -> bool {
         matches!(self.state.peers.read().await.get(id), Some(peer) if peer.instance_id == *instance_id)
     }
@@ -50,6 +57,9 @@ impl PeerManager {
         self.state.peers.read().await.values().cloned().collect()
     }
 
+    /// Returns the addresses of peers that share the sync directory
+    /// containing `entry`, i.e. the recipients of an outbound
+    /// metadata broadcast for that entry.
     pub async fn get_peers_to_send_metadata(&self, entry: &EntryInfo) -> Vec<IpAddr> {
         let root_dir = entry.get_sync_dir();
 

--- a/app/src/application/sync.rs
+++ b/app/src/application/sync.rs
@@ -22,6 +22,13 @@ use crate::{
 use std::sync::Arc;
 use tokio::io;
 
+/// Top-level orchestrator that wires the application's four concurrent
+/// subsystems — transport, presence, file watcher, and HTTP server —
+/// around a shared `AppState`.
+///
+/// Generic over each port so tests can inject in-memory adapters; the
+/// production wiring is `Synchronizer<NotifyFileWatcher, TcpAdapter,
+/// SqliteDb, MdnsAdapter>` (see `new_default_with_dirs`).
 pub struct Synchronizer<
     W: FileWatcherInterface,
     T: TransportInterface,
@@ -37,6 +44,9 @@ pub struct Synchronizer<
 }
 
 impl Synchronizer<NotifyFileWatcher, TcpAdapter, SqliteDb, MdnsAdapter> {
+    /// Builds a `Synchronizer` wired with the production adapters and
+    /// the supplied `SyncheDirs` (so the binary uses OS dirs and tests
+    /// can inject isolated temporary ones).
     pub async fn new_default_with_dirs(dirs: SyncheDirs) -> Self {
         let state = AppState::new(dirs, default_ports()).await;
 
@@ -48,6 +58,14 @@ impl Synchronizer<NotifyFileWatcher, TcpAdapter, SqliteDb, MdnsAdapter> {
         Self::new(state, notify, mdns_adapter, tcp_adapter, sqlite_adapter).await
     }
 
+    /// Runs the synchronizer in a loop, rebuilding the entire
+    /// `Synchronizer` whenever `run` returns the sentinel
+    /// `HOME_PATH_CHANGED:<old>:<new>` error so an in-flight
+    /// `home_path` change from the GUI is applied without restarting
+    /// the process. Any other error propagates and exits the loop.
+    ///
+    /// Anything touching shutdown or restart paths must preserve this
+    /// sentinel contract.
     pub async fn run_default_with_restart(dirs: SyncheDirs) -> io::Result<()> {
         loop {
             let mut synchronizer = Self::new_default_with_dirs(dirs.clone()).await;
@@ -84,6 +102,8 @@ impl Synchronizer<NotifyFileWatcher, TcpAdapter, SqliteDb, MdnsAdapter> {
 impl<W: FileWatcherInterface, T: TransportInterface, P: PersistenceInterface, D: PresenceInterface>
     Synchronizer<W, T, P, D>
 {
+    /// Wires the synchronizer with explicit adapters for every port —
+    /// the seam tests use to inject in-memory or fake implementations.
     pub async fn new(
         state: Arc<AppState>,
         watch_adapter: W,
@@ -128,6 +148,10 @@ impl<W: FileWatcherInterface, T: TransportInterface, P: PersistenceInterface, D:
         }
     }
 
+    /// Runs the four subsystems concurrently until any one exits or a
+    /// shutdown signal arrives (`SIGINT`/`SIGTERM`/`SIGHUP` on Unix,
+    /// `Ctrl+C` elsewhere). Returns the `HOME_PATH_CHANGED:` sentinel
+    /// untouched so `run_default_with_restart` can rebuild.
     pub async fn run(&mut self) -> io::Result<()> {
         #[cfg(unix)]
         {
@@ -216,6 +240,7 @@ impl<W: FileWatcherInterface, T: TransportInterface, P: PersistenceInterface, D:
         )
     }
 
+    /// Cleanly stops background services (currently presence).
     pub async fn shutdown(&mut self) -> io::Result<()> {
         self.presence_service.shutdown().await;
         tracing::info!("Synche gracefully shutdown");

--- a/app/src/application/watcher/buffer.rs
+++ b/app/src/application/watcher/buffer.rs
@@ -7,6 +7,14 @@ use tokio::{io, sync::RwLock};
 
 const DEBOUNCE_DURATION: Duration = Duration::from_secs(1);
 
+/// In-memory debounce buffer that coalesces bursty filesystem events
+/// into a single settled event per path.
+///
+/// Home events are debounced per `RelativePath` so rapid writes to the
+/// same file collapse to one downstream message; config events are
+/// debounced as a single slot because `config.toml` is monolithic. An
+/// event is flushed once `DEBOUNCE_DURATION` has elapsed since the
+/// last write for that key.
 pub struct WatcherBuffer {
     home_chan: MutexChannel<HomeWatcherEvent>,
     config_chan: MutexChannel<ConfigWatcherEvent>,
@@ -143,17 +151,14 @@ mod tests {
         let event = create_test_event("file.txt", &temp);
         buffer.insert_home_event(event.clone()).await;
 
-        // Should NOT receive immediately (before debounce window)
         let result = tokio::time::timeout(DEBOUNCE_DURATION / 2, buffer.next_home_event()).await;
         assert!(
             result.is_err(),
             "Event should not be delivered before debounce window"
         );
 
-        // Wait for debounce window to complete
         sleep(DEBOUNCE_DURATION + Duration::from_millis(100)).await;
 
-        // Should receive now
         let received = buffer.next_home_event().await;
         assert!(
             received.is_some(),
@@ -183,7 +188,6 @@ mod tests {
         let path = temp.path().join("file.txt");
         std::fs::write(&path, "initial").unwrap();
 
-        // Insert 5 events for same path within debounce window
         for i in 0..5 {
             std::fs::write(&path, format!("version{}", i)).unwrap();
             let event = HomeWatcherEvent::EntryCreateOrModify(WatcherEventPath {
@@ -194,14 +198,11 @@ mod tests {
             sleep(DEBOUNCE_DURATION / 10).await;
         }
 
-        // Wait for debounce window (with extra margin)
         sleep(DEBOUNCE_DURATION * 2).await;
 
-        // Should receive only ONE event (the last one)
         let received = buffer.next_home_event().await;
         assert!(received.is_some(), "Should receive one debounced event");
 
-        // No more events should be available
         let result = tokio::time::timeout(DEBOUNCE_DURATION / 10, buffer.next_home_event()).await;
         assert!(result.is_err(), "Should not receive duplicate events");
     }
@@ -224,10 +225,8 @@ mod tests {
         buffer.insert_home_event(event2).await;
         buffer.insert_home_event(event3).await;
 
-        // Wait for debounce window (with margin)
         sleep(DEBOUNCE_DURATION + Duration::from_millis(200)).await;
 
-        // Should receive all 3 events
         let mut received_paths = vec![];
         for _ in 0..3 {
             if let Some(HomeWatcherEvent::EntryCreateOrModify(path)) =
@@ -240,7 +239,6 @@ mod tests {
         received_paths.sort();
         assert_eq!(received_paths, vec!["file1.txt", "file2.txt", "file3.txt"]);
 
-        // No more events
         let result = tokio::time::timeout(DEBOUNCE_DURATION / 10, buffer.next_home_event()).await;
         assert!(result.is_err());
     }
@@ -258,7 +256,6 @@ mod tests {
         let config_path = temp.path().join("config.toml");
         std::fs::write(&config_path, "test1").unwrap();
 
-        // Insert multiple config events within debounce window
         for i in 0..3 {
             std::fs::write(&config_path, format!("test{}", i)).unwrap();
             let event = ConfigWatcherEvent::Modify;
@@ -266,14 +263,11 @@ mod tests {
             sleep(DEBOUNCE_DURATION / 5).await;
         }
 
-        // Wait for debounce window (with margin)
         sleep(DEBOUNCE_DURATION + Duration::from_millis(200)).await;
 
-        // Should receive only ONE config event (last one)
         let received = buffer.next_config_event().await;
         assert!(received.is_some(), "Should receive one config event");
 
-        // No more events
         let result = tokio::time::timeout(DEBOUNCE_DURATION / 10, buffer.next_config_event()).await;
         assert!(
             result.is_err(),
@@ -299,7 +293,6 @@ mod tests {
             canonical: CanonicalPath::new(&path).unwrap(),
         };
 
-        // Insert CreateOrModify, then Remove for same path (within debounce window)
         buffer
             .insert_home_event(HomeWatcherEvent::EntryCreateOrModify(watcher_path.clone()))
             .await;
@@ -308,15 +301,12 @@ mod tests {
             .insert_home_event(HomeWatcherEvent::EntryRemove(watcher_path.clone()))
             .await;
 
-        // Wait for debounce window (with margin)
         sleep(DEBOUNCE_DURATION + Duration::from_millis(200)).await;
 
-        // Should receive only the LAST event (Remove)
         let received = buffer.next_home_event().await;
         assert!(received.is_some());
         assert!(matches!(received, Some(HomeWatcherEvent::EntryRemove(_))));
 
-        // No more events
         let result = tokio::time::timeout(DEBOUNCE_DURATION / 10, buffer.next_home_event()).await;
         assert!(result.is_err());
     }
@@ -344,14 +334,12 @@ mod tests {
         // Wait another 80% (total 160% from first, but only 80% from second)
         sleep(DEBOUNCE_DURATION * 4 / 5).await;
 
-        // Should NOT have received event yet (timer was reset)
         let result = tokio::time::timeout(DEBOUNCE_DURATION / 10, buffer.next_home_event()).await;
         assert!(result.is_err(), "Timer should have been reset");
 
         // Wait remaining time (30% more to complete the debounce)
         sleep(DEBOUNCE_DURATION * 3 / 10).await;
 
-        // Now should receive
         let received = buffer.next_home_event().await;
         assert!(received.is_some());
     }

--- a/app/src/application/watcher/file_watcher.rs
+++ b/app/src/application/watcher/file_watcher.rs
@@ -14,6 +14,11 @@ use std::{collections::HashSet, sync::Arc};
 use tokio::{io, sync::mpsc::Sender};
 use tracing::{error, info, trace, warn};
 
+/// Application service that consumes events from a
+/// `FileWatcherInterface` adapter, debounces them through a
+/// `WatcherBuffer`, and reacts: home-tree changes become outbound
+/// `Metadata` transfers and persistence writes; `config.toml` changes
+/// are applied live (including the `home_path` restart sentinel).
 pub struct FileWatcher<T: FileWatcherInterface, P: PersistenceInterface> {
     adapter: T,
     buffer: WatcherBuffer,
@@ -41,6 +46,9 @@ impl<T: FileWatcherInterface, P: PersistenceInterface> FileWatcher<T, P> {
         }
     }
 
+    /// Starts watching both streams and drives the buffer plus the
+    /// four event-handling tasks concurrently. Returns when any task
+    /// errors or terminates.
     pub async fn run(&mut self) -> io::Result<()> {
         self.adapter.watch_home().await?;
         self.adapter.watch_config().await?;

--- a/app/src/application/watcher/interface.rs
+++ b/app/src/application/watcher/interface.rs
@@ -5,12 +5,32 @@ use crate::{
 use std::sync::Arc;
 use tokio::io;
 
+/// Port for filesystem-event observation.
+///
+/// An implementor must surface two independent event streams:
+///
+/// - **home** events (entry created/modified/removed) from anywhere
+///   under the active `home_path`, used to drive sync;
+/// - **config** events from `config.toml` only, used to apply live
+///   edits to the user's settings.
+///
+/// Implementations are expected to debounce rapid bursts so callers
+/// receive a settled view rather than per-syscall noise. Both
+/// `watch_*` methods are called once at startup; the corresponding
+/// `next_*_event` methods are then polled in a loop.
 pub trait FileWatcherInterface {
     fn new(state: Arc<AppState>) -> Self;
 
+    /// Starts watching the user's home directory. Idempotent across
+    /// repeated calls is not required.
     async fn watch_home(&mut self) -> io::Result<()>;
+    /// Starts watching `config.toml`.
     async fn watch_config(&mut self) -> io::Result<()>;
 
+    /// Awaits the next debounced home-tree event, or `None` if the
+    /// underlying stream has terminated.
     async fn next_home_event(&self) -> io::Result<Option<HomeWatcherEvent>>;
+    /// Awaits the next debounced `config.toml` event, or `None` if the
+    /// underlying stream has terminated.
     async fn next_config_event(&self) -> io::Result<Option<ConfigWatcherEvent>>;
 }

--- a/app/src/domain/cfg/config.rs
+++ b/app/src/domain/cfg/config.rs
@@ -5,6 +5,12 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use tokio::{fs, io};
 
+/// On-disk representation of `config.toml`.
+///
+/// Holds the user's chosen `home_path` and the list of sync
+/// directories. Edits to this file are observed by the config watcher
+/// and applied live; changing `home_path` triggers the synchronizer's
+/// restart loop (see `Synchronizer::run_default_with_restart`).
 #[derive(Serialize, Deserialize)]
 pub struct Config {
     pub home_path: CanonicalPath,

--- a/app/src/domain/cfg/directory.rs
+++ b/app/src/domain/cfg/directory.rs
@@ -1,6 +1,10 @@
 use crate::domain::{RelativePath, SyncDirectory};
 use serde::{Deserialize, Serialize};
 
+/// On-disk representation of a single entry in the `directory = [...]`
+/// list of `config.toml`. Mirrors `SyncDirectory` but exists separately
+/// so the serialized config schema stays decoupled from the in-memory
+/// domain type.
 #[derive(Serialize, Deserialize)]
 pub struct ConfigDirectory {
     pub name: RelativePath,
@@ -11,6 +15,7 @@ impl ConfigDirectory {
         Self { name: name.into() }
     }
 
+    /// Returns the in-memory `SyncDirectory` representation.
     pub fn to_sync(&self) -> SyncDirectory {
         SyncDirectory {
             name: self.name.clone(),

--- a/app/src/domain/chan.rs
+++ b/app/src/domain/chan.rs
@@ -3,6 +3,13 @@ use tokio::sync::{
     mpsc::{self, Receiver, Sender},
 };
 
+/// An mpsc channel whose receiver is shareable across tasks via a
+/// `Mutex`.
+///
+/// Use this when multiple owners (typically behind an `Arc`) need to
+/// pull from the same single-consumer queue and arbitrate access
+/// themselves. The sender side stays a plain `mpsc::Sender` and can be
+/// cloned freely.
 pub struct MutexChannel<K> {
     pub tx: Sender<K>,
     pub rx: Mutex<Receiver<K>>,
@@ -17,11 +24,20 @@ impl<K> MutexChannel<K> {
         }
     }
 
+    /// Acquires the receiver lock and waits for the next message.
+    ///
+    /// Returns `None` once all senders have been dropped.
     pub async fn recv(&self) -> Option<K> {
         self.rx.lock().await.recv().await
     }
 }
 
+/// A fan-out broadcast channel whose subscribers are created on demand.
+///
+/// Used to push live updates (`ServerEvent`s) to every connected SSE
+/// client. Late subscribers do not see messages produced before they
+/// subscribed; slow subscribers may lag and lose messages per
+/// `tokio::sync::broadcast` semantics.
 pub struct BroadcastChannel<T: Clone> {
     tx: broadcast::Sender<T>,
 }

--- a/app/src/domain/directory.rs
+++ b/app/src/domain/directory.rs
@@ -1,12 +1,18 @@
 use crate::domain::{ConfigDirectory, RelativePath};
 use serde::{Deserialize, Serialize};
 
+/// A top-level synchronized directory under the Synche home path.
+///
+/// Sync directories are the root scopes that peers can replicate
+/// independently — entries inside them are addressed by paths relative
+/// to home.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncDirectory {
     pub name: RelativePath,
 }
 
 impl SyncDirectory {
+    /// Returns the on-disk `ConfigDirectory` representation for `config.toml`.
     pub fn to_config(&self) -> ConfigDirectory {
         ConfigDirectory {
             name: self.name.clone(),

--- a/app/src/domain/entry/info.rs
+++ b/app/src/domain/entry/info.rs
@@ -3,6 +3,12 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use uuid::Uuid;
 
+/// Metadata for a single synchronized filesystem entry.
+///
+/// `hash` is `None` for directories and the SHA-256 of the contents for
+/// files (with the sentinel `REMOVED_HASH` marking a tombstone — see
+/// `set_removed_hash`). `version` is the `VersionVector` that drives
+/// conflict resolution; see `VersionCmp`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntryInfo {
     pub name: RelativePath,
@@ -11,6 +17,7 @@ pub struct EntryInfo {
     pub version: VersionVector,
 }
 
+/// Whether an `EntryInfo` describes a file or a directory.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum EntryKind {
     File,
@@ -18,6 +25,13 @@ pub enum EntryKind {
 }
 
 impl EntryInfo {
+    /// Compares two entries to decide which side wins.
+    ///
+    /// Equal `kind` and `hash` short-circuits to `Equal` regardless of
+    /// version vectors. Otherwise the comparison walks both vectors:
+    /// strictly newer on every peer → `KeepSelf`/`KeepOther`, mixed →
+    /// `Conflict`. A `Conflict` is materialized as a conflict file by
+    /// the caller rather than overwriting either side.
     pub fn compare(&self, other: &EntryInfo) -> VersionCmp {
         if self.kind == other.kind && self.hash == other.hash {
             return VersionCmp::Equal;
@@ -57,10 +71,14 @@ impl EntryInfo {
         self.name.sync_dir()
     }
 
+    /// Marks the entry as removed by stamping a sentinel hash, so the
+    /// tombstone propagates through the same metadata channel as live
+    /// updates.
     pub fn set_removed_hash(&mut self) {
         self.hash = Some(REMOVED_HASH.to_string());
     }
 
+    /// Returns `true` if the entry's hash matches the removal sentinel.
     pub fn is_removed(&self) -> bool {
         matches!(self.hash.as_deref(), Some(REMOVED_HASH))
     }

--- a/app/src/domain/entry/version.rs
+++ b/app/src/domain/entry/version.rs
@@ -1,11 +1,26 @@
 use std::collections::HashMap;
 use uuid::Uuid;
 
+/// Per-device monotonic counters that drive Synche's conflict
+/// resolution.
+///
+/// Keys are device `local_id`s; values are bumped on every local
+/// change. Two versions are comparable per `EntryInfo::compare`.
 pub type VersionVector = HashMap<Uuid, u64>;
 
+/// The outcome of comparing two `EntryInfo` version vectors.
+///
+/// `Conflict` is not an error condition — it means the two sides have
+/// concurrent edits and the caller must materialize a conflict file
+/// rather than choose a winner.
 pub enum VersionCmp {
+    /// Same kind and same hash — nothing to do.
     Equal,
+    /// Local version dominates the remote one; keep the local entry.
     KeepSelf,
+    /// Remote version dominates the local one; adopt the remote entry.
     KeepOther,
+    /// Concurrent edits on both sides; preserve both by writing a
+    /// conflict file.
     Conflict,
 }

--- a/app/src/domain/peer.rs
+++ b/app/src/domain/peer.rs
@@ -3,6 +3,13 @@ use serde::Serialize;
 use std::{collections::HashMap, net::IpAddr, time::SystemTime};
 use uuid::Uuid;
 
+/// A remote Synche instance currently visible on the network.
+///
+/// `id` is the peer's persistent device identifier; `instance_id` is
+/// regenerated on every process start, so a change to it signals that
+/// the peer restarted even when `id` and `addr` stay the same.
+/// `last_seen` is refreshed on every presence announcement and is used
+/// to evict peers that have gone silent.
 #[derive(Debug, Clone, Serialize)]
 pub struct Peer {
     pub id: Uuid,
@@ -14,6 +21,9 @@ pub struct Peer {
 }
 
 impl Peer {
+    /// Constructs a `Peer`, stamping `last_seen` with the current time
+    /// and stripping the trailing `.local` suffix that mDNS appends to
+    /// hostnames.
     pub fn new(
         id: Uuid,
         addr: IpAddr,

--- a/app/src/domain/ports.rs
+++ b/app/src/domain/ports.rs
@@ -1,5 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+/// The three network ports the application binds.
+///
+/// `http` serves the GUI and JSON API; `presence` is the mDNS discovery
+/// port; `transport` is the TCP port that carries handshakes, metadata,
+/// requests, and entry transfers.
+///
+/// A value of `0` requests an OS-assigned ephemeral port — tests rely on
+/// this so they don't collide with the production defaults defined in
+/// `AppState::default_ports`.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct AppPorts {
     pub http: u16,

--- a/app/src/domain/sse.rs
+++ b/app/src/domain/sse.rs
@@ -3,15 +3,24 @@ use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use uuid::Uuid;
 
+/// Events broadcast to the GUI over Server-Sent Events to keep the
+/// frontend's view of peers and sync directories in sync with the
+/// running application.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ServerEvent {
+    /// A new peer was discovered or an existing one reconnected.
     PeerConnected {
         id: Uuid,
         addr: IpAddr,
         hostname: String,
     },
+    /// A peer was evicted (timed out, or explicitly disconnected).
     PeerDisconnected(Uuid),
+    /// A sync directory was added to the local config.
     SyncDirectoryAdded(RelativePath),
+    /// A sync directory was removed from the local config.
     SyncDirectoryRemoved(RelativePath),
+    /// The server is restarting (e.g. after a `home_path` change) — the
+    /// GUI should reconnect.
     ServerRestart,
 }

--- a/app/src/domain/transport.rs
+++ b/app/src/domain/transport.rs
@@ -3,16 +3,30 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, net::IpAddr};
 use uuid::Uuid;
 
+/// An inbound transport message, paired with the metadata that
+/// identifies which peer sent it.
 pub struct TransportEvent {
     pub payload: TransportData,
     pub metadata: TransportMetadata,
 }
 
+/// Provenance of an inbound `TransportEvent` — who sent it and from
+/// where — extracted from the connection rather than the payload.
 pub struct TransportMetadata {
     pub source_id: Uuid,
     pub source_ip: IpAddr,
 }
 
+/// The four wire-protocol message kinds exchanged between peers.
+///
+/// - `HandshakeSyn` / `HandshakeAck`: two-step exchange of identity,
+///   sync directories, and current entry metadata when peers discover
+///   each other.
+/// - `Metadata`: a unidirectional update advertising the sender's view
+///   of a single entry (insert, modify, or removal tombstone).
+/// - `Request`: asks the recipient to send the bytes for an entry the
+///   sender wants to fetch.
+/// - `Transfer`: streams the actual bytes for a requested entry.
 pub enum TransportData {
     HandshakeSyn(HandshakeData),
     HandshakeAck(HandshakeData),
@@ -21,6 +35,8 @@ pub enum TransportData {
     Transfer(EntryInfo),
 }
 
+/// Payload for the handshake exchange — everything a peer needs to
+/// reconcile its world view against the sender's on first contact.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct HandshakeData {
     pub hostname: String,
@@ -29,6 +45,11 @@ pub struct HandshakeData {
     pub entries: HashMap<RelativePath, EntryInfo>,
 }
 
+/// Outbound transport intent enqueued by application services for the
+/// transport sender to dispatch.
+///
+/// Mirrors `TransportData` but carries the target peer address since the
+/// sender, unlike the receiver, must know where to send.
 pub enum TransportChannelData {
     HandshakeSyn(IpAddr),
     _HandshakeAck(IpAddr),

--- a/app/src/infra/http/api.rs
+++ b/app/src/infra/http/api.rs
@@ -37,6 +37,8 @@ struct SetHomePathParams {
     pub path: String,
 }
 
+/// JSON API routes — peer listing, sync-directory management,
+/// `home_path` updates, and the SSE stream of `ServerEvent`s.
 pub fn routes<P: PersistenceInterface>(
     state: Arc<AppState>,
     peer_manager: Arc<PeerManager>,

--- a/app/src/infra/http/gui.rs
+++ b/app/src/infra/http/gui.rs
@@ -13,6 +13,8 @@ struct GuiState<P: PersistenceInterface> {
     pub entry_manager: Arc<EntryManager<P>>,
 }
 
+/// GUI routes — renders the index template at `/` and serves static
+/// assets from `gui/static/` under `/static`.
 pub fn routes<P: PersistenceInterface>(
     state: Arc<AppState>,
     engine: Environment<'static>,

--- a/app/src/infra/http/routes.rs
+++ b/app/src/infra/http/routes.rs
@@ -8,6 +8,8 @@ use axum::Router;
 use minijinja::Environment;
 use std::sync::Arc;
 
+/// Composes the GUI and JSON API routers into the application's
+/// single top-level `axum::Router`.
 pub fn build_router<P: PersistenceInterface>(
     state: Arc<AppState>,
     peer_manager: Arc<PeerManager>,

--- a/app/src/infra/http/server.rs
+++ b/app/src/infra/http/server.rs
@@ -9,6 +9,9 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tower_http::trace::TraceLayer;
 
+/// Binds the HTTP listener on the configured port and serves the GUI
+/// and JSON API. Runs until the listener errors or the task is
+/// cancelled by the synchronizer's `tokio::select!`.
 pub async fn run<P: PersistenceInterface>(
     state: Arc<AppState>,
     peer_manager: Arc<PeerManager>,
@@ -26,6 +29,8 @@ pub async fn run<P: PersistenceInterface>(
     axum::serve(listener, router).await
 }
 
+/// Builds the minijinja environment with the GUI template embedded at
+/// compile time so no runtime template lookup is needed.
 pub fn init_template_engine() -> Environment<'static> {
     let mut engine = Environment::new();
     engine

--- a/app/src/infra/network/mdns.rs
+++ b/app/src/infra/network/mdns.rs
@@ -13,6 +13,13 @@ use uuid::Uuid;
 const SERVICE_TYPE: &str = "_synche._udp.local.";
 const RETRY_COUNT: usize = 3;
 
+/// `mdns-sd` adapter implementing `PresenceInterface`.
+///
+/// Browses the `_synche._udp.local.` service to learn about peers and
+/// publishes this instance's own record (with its `instance_id` in the
+/// TXT properties) so other peers can detect restarts. IPv6 is
+/// disabled at the daemon level because the application's transport
+/// addresses are IPv4-only.
 pub struct MdnsAdapter {
     state: Arc<AppState>,
     daemon: ServiceDaemon,

--- a/app/src/infra/network/tcp/adapter.rs
+++ b/app/src/infra/network/tcp/adapter.rs
@@ -11,6 +11,12 @@ use tokio::{io::AsyncReadExt, net::TcpListener};
 use tracing::{trace, warn};
 use uuid::Uuid;
 
+/// TCP adapter implementing `TransportInterface`.
+///
+/// Owns the listening socket plus a `TcpSender` / `TcpReceiver` pair
+/// that implement the wire format. Listener bind/accept failures are
+/// fatal; framing errors on an accepted connection are logged and the
+/// loop continues so a single bad peer cannot stop the synchronizer.
 pub struct TcpAdapter {
     sender: TcpSender,
     receiver: TcpReceiver,

--- a/app/src/infra/network/tcp/kind.rs
+++ b/app/src/infra/network/tcp/kind.rs
@@ -1,5 +1,10 @@
 use crate::{application::network::transport::interface::TransportError, domain::TransportData};
 
+/// One-byte tag prefixed to every TCP message so the receiver knows
+/// how to decode the rest of the frame.
+///
+/// The discriminants are part of the wire format — renumbering them
+/// would break compatibility with peers running older builds.
 #[repr(u8)]
 pub enum TcpStreamKind {
     HandshakeSyn = 1,

--- a/app/src/infra/network/tcp/receiver.rs
+++ b/app/src/infra/network/tcp/receiver.rs
@@ -17,6 +17,14 @@ use tokio::{
 };
 use uuid::Uuid;
 
+/// Inbound side of the TCP wire format.
+///
+/// Decodes a `TcpStreamKind`-tagged payload back into a
+/// `TransportData`. For bulk transfers, the bytes are written to a
+/// per-transfer staging file in the OS temp directory and only moved
+/// to their final location after the streamed SHA-256 matches the
+/// advertised hash and safety validation passes; corrupt or unsafe
+/// transfers are dropped without touching the user's home tree.
 pub struct TcpReceiver {
     state: Arc<AppState>,
 }

--- a/app/src/infra/network/tcp/sender.rs
+++ b/app/src/infra/network/tcp/sender.rs
@@ -16,6 +16,13 @@ use tokio::{
 };
 use tracing::{info, warn};
 
+/// Outbound side of the TCP wire format.
+///
+/// Each `send_*` method opens a fresh connection to the target peer,
+/// writes the device id, a `TcpStreamKind` tag, and the kind-specific
+/// payload. Bulk transfers use `stream_file_to` to chunk content with
+/// a streaming SHA-256 so the receiver can detect mid-transfer
+/// changes.
 pub struct TcpSender {
     state: Arc<AppState>,
 }
@@ -97,6 +104,11 @@ impl TcpSender {
         Ok(())
     }
 
+    /// Streams an entry's bytes to `target`, framed by the wire
+    /// protocol: device id, kind tag, metadata-length + JSON, entry
+    /// size, then `entry_size` bytes of content. Logs a warning (but
+    /// still completes the transfer) if the file changes during
+    /// streaming so the receiver can reject by hash mismatch.
     async fn send_entry(&self, target: IpAddr, entry: EntryInfo) -> TransportResult<()> {
         let socket = SocketAddr::new(target, self.state.ports().transport);
         let mut stream = TcpStream::connect(socket).await?;
@@ -115,24 +127,14 @@ impl TcpSender {
 
         info!(kind = kind.to_string(), target = ?target, entry_name = ?&entry.name, "sending");
 
-        // Write self peer id
         stream.write_all(self.state.local_id().as_bytes()).await?;
-
-        // Write sync kind
         stream.write_all(&[kind as u8]).await?;
-
-        // Write metadata json size
         stream
             .write_all(&u32::to_be_bytes(metadata_json.len() as u32))
             .await?;
-
-        // Write metadata json
         stream.write_all(&metadata_json).await?;
-
-        // Write entry size
         stream.write_all(&u64::to_be_bytes(entry_size)).await?;
 
-        // Stream entry contents in chunks
         let computed_hash =
             Self::stream_file_to(&mut file, &mut stream, entry_size, TRANSFER_CHUNK_SIZE).await?;
 

--- a/app/src/infra/persistence/sqlite.rs
+++ b/app/src/infra/persistence/sqlite.rs
@@ -10,6 +10,11 @@ use sqlx::{
 };
 use std::path::Path;
 
+/// `sqlx`-backed SQLite adapter for `PersistenceInterface`.
+///
+/// Stores one row per `EntryInfo` and serializes the `VersionVector`
+/// inline. Accepts `:memory:` as a path so tests can run against an
+/// in-process database without touching disk.
 pub struct SqliteDb {
     pool: Pool<Sqlite>,
 }
@@ -364,7 +369,6 @@ mod tests {
     async fn test_long_hash() {
         let db = create_test_db().await;
 
-        // SHA256 hash (64 characters)
         let long_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
         let entry = create_test_entry("file.txt", EntryKind::File, Some(long_hash.to_string()));
 

--- a/app/src/infra/watcher/notify.rs
+++ b/app/src/infra/watcher/notify.rs
@@ -16,6 +16,13 @@ use tokio::{
     },
 };
 
+/// `notify`-crate adapter for `FileWatcherInterface`.
+///
+/// Runs two independent platform watchers — one recursive on the home
+/// directory, one non-recursive on `config.toml` — and translates
+/// `notify::Event`s into the application's `HomeWatcherEvent` /
+/// `ConfigWatcherEvent` enums while filtering out paths under `.git/`
+/// and `.DS_Store` noise.
 pub struct NotifyFileWatcher {
     state: Arc<AppState>,
     home_watcher: RecommendedWatcher,

--- a/app/src/utils/dirs.rs
+++ b/app/src/utils/dirs.rs
@@ -58,18 +58,23 @@ impl SyncheDirs {
         &self.logs
     }
 
+    /// Path of the persistent `device_id` file. The UUID inside it is
+    /// generated on first run and reused on every subsequent start.
     pub fn device_id_file(&self) -> CanonicalPath {
         self.data.join("device_id")
     }
 
+    /// Directory where the rolling log appender writes daily files.
     pub fn log_dir(&self) -> &CanonicalPath {
         &self.logs
     }
 
+    /// Path of `config.toml` — the user-editable settings file.
     pub fn config_file(&self) -> CanonicalPath {
         self.config.join("config.toml")
     }
 
+    /// Path of the SQLite database that stores entry metadata.
     pub fn data_db_file(&self) -> CanonicalPath {
         self.data.join("data.db")
     }

--- a/app/src/utils/fs.rs
+++ b/app/src/utils/fs.rs
@@ -34,6 +34,9 @@ pub fn default_home_dir() -> io::Result<CanonicalPath> {
     CanonicalPath::new(&dir)
 }
 
+/// Returns the lowercase hex SHA-256 of the file at `path`, reading
+/// it in 64 KiB chunks so memory usage stays flat regardless of file
+/// size.
 pub async fn compute_hash(path: &CanonicalPath) -> io::Result<String> {
     let mut file = File::open(path).await?;
     let mut hasher = Sha256::new();
@@ -51,6 +54,9 @@ pub async fn compute_hash(path: &CanonicalPath) -> io::Result<String> {
     Ok(hash)
 }
 
+/// Returns `true` if `path`'s final component is the macOS metadata
+/// file `.DS_Store`. These files are filtered out by the watcher and
+/// the entry scanner because syncing them is never useful.
 pub fn is_ds_store<P: AsRef<Path>>(path: P) -> bool {
     matches!(path.as_ref().file_name(), Some(name) if name == ".DS_Store")
 }

--- a/app/src/utils/logging.rs
+++ b/app/src/utils/logging.rs
@@ -31,6 +31,16 @@ fn default_directive() -> &'static str {
     }
 }
 
+/// Initialises the global `tracing` subscriber for the binary.
+///
+/// Pipes events to two layers: stdout (ANSI when stdout is a TTY,
+/// plain text otherwise, no target) and a daily-rotated file under
+/// `log_dir` (no ANSI, target included). Honours `RUST_LOG` and falls
+/// back to `synche=debug,warn` in debug builds / `synche=info,warn`
+/// in release.
+///
+/// The returned `LogGuards` MUST be held for the lifetime of `main`
+/// — dropping it discards in-flight log lines.
 pub fn init(log_dir: &Path) -> LogGuards {
     let file_appender = RollingFileAppender::builder()
         .rotation(Rotation::DAILY)


### PR DESCRIPTION
## Summary

Closes #3.

- Adds documentation comments (`///`) across the hexagonal layers — every major struct/enum/trait and any public method whose contract isn't self-evident. Priority targets per the issue: the `*Interface` ports, the `Synchronizer` orchestrator, `AppState`, and the `VersionCmp::Conflict` invariant.
- Strips pure code-narration comments (`// Write self peer id` above a `stream.write_all(local_id)`, assert-restating step markers in the watcher buffer tests, etc.) while keeping every "why" comment that documents a race-condition rationale, ordering constraint, or test-isolation choice.
- No behavior changes; matches the existing doc style from `utils/fs.rs` and `domain/fs/path.rs`.

## Test plan

- [x] `cargo clippy -p synche -- -D warnings` clean
- [x] `cargo test -p synche` — 99 passed
- [x] `cargo fmt --check` clean
- [x] Spot-check `cargo doc -p synche --no-deps --open` rendering before merge