### PR TITLE
docs: add HTTP API reference and architecture guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ You can either download a prebuilt binary or build it from source:
 -   **[Latest Release](https://github.com/matx64/synche/releases/latest)** (Recommended for most users)
 -   **[Build Guide](docs/BUILD.md)** (For developers who want to build from source)
 
+## Documentation
+
+-   **[HTTP API Reference](docs/API.md)** — endpoint details, query parameters, response codes, and SSE event shapes.
+-   **[Architecture Guide](docs/ARCHITECTURE.md)** — hexagonal layout, version vectors and conflict resolution, TCP wire format, `home_path` restart contract, and mDNS discovery.
+
 ## Contributing & Feedback
 
 This project is in active development, and contributions are welcome. Check out the **[Contributing Guide](docs/CONTRIBUTING.md)** for more details.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,235 @@
+# HTTP API Reference
+
+Synche exposes a small HTTP API for managing sync directories and streaming real-time events to the GUI.  The server runs on port **42880** by default (configurable in `AppState`).
+
+All requests use query parameters — there are no JSON request bodies.  Responses carry only an HTTP status code; error details are emitted to the server log.
+
+> **Source:** [`app/src/infra/http/api.rs`](../app/src/infra/http/api.rs) · [`app/src/domain/sse.rs`](../app/src/domain/sse.rs)
+
+---
+
+## Endpoints
+
+### `GET /api/events` — Server-Sent Events stream
+
+Streams [`ServerEvent`](#server-sent-events) objects to the client as newline-delimited JSON using the SSE protocol.  The GUI subscribes to this endpoint on load and uses it to update its peer list and sync-directory list in real time.
+
+| | |
+|---|---|
+| **Method** | `GET` |
+| **Query params** | none |
+| **Content-Type** | `text/event-stream` |
+| **Status** | `200 OK` (stream never ends until the server restarts or the broadcast channel closes) |
+
+**Behaviour:**
+
+- Each event is serialized with `serde_json` and delivered as `data: <json>\n\n`.
+- The broadcast channel has a capacity of **100 events**.  If a client falls behind, it is warned in the log and continues receiving subsequent messages (intermediate events are skipped).
+- When the broadcast channel closes (e.g. after a clean shutdown), the stream ends.
+- A `ServerRestart` event is sent before any in-process restart so the client knows to reconnect.
+
+---
+
+### `POST /api/add-sync-dir` — Add a sync directory
+
+Appends a directory to the sync configuration.
+
+| | |
+|---|---|
+| **Method** | `POST` |
+| **Query params** | `name` — directory name relative to `home_path` (leading/trailing whitespace is trimmed) |
+| **Request body** | none |
+
+| Status | Meaning |
+|--------|---------|
+| `201 Created` | Directory was added successfully |
+| `409 Conflict` | Directory is already present in the configuration |
+| `500 Internal Server Error` | Unexpected I/O error writing `config.toml` |
+
+**Example:**
+
+```
+POST /api/add-sync-dir?name=Photos
+```
+
+---
+
+### `POST /api/remove-sync-dir` — Remove a sync directory
+
+Removes a directory from the sync configuration.  The operation is idempotent — removing a directory that does not exist in the config returns `200 OK`.
+
+| | |
+|---|---|
+| **Method** | `POST` |
+| **Query params** | `name` — directory name relative to `home_path` (leading/trailing whitespace is trimmed) |
+| **Request body** | none |
+
+| Status | Meaning |
+|--------|---------|
+| `200 OK` | Directory removed (or was not present) |
+| `500 Internal Server Error` | Unexpected I/O error writing `config.toml` |
+
+**Example:**
+
+```
+POST /api/remove-sync-dir?name=Archive
+```
+
+---
+
+### `POST /api/set-home-path` — Change the home directory
+
+Updates the root directory used as the base for all sync paths.  If the directory does not yet exist it (and any missing parents) is created.  Changing this value triggers an in-process restart of the synchronizer — see the [restart sentinel contract](ARCHITECTURE.md#home_path-change--restart-sentinel-contract) for details.
+
+| | |
+|---|---|
+| **Method** | `POST` |
+| **Query params** | `path` — absolute filesystem path |
+| **Request body** | none |
+
+| Status | Meaning |
+|--------|---------|
+| `200 OK` | Home path updated and written to `config.toml` |
+| `400 Bad Request` | `path` exists but is a file rather than a directory |
+| `500 Internal Server Error` | Other I/O error (e.g. permission denied) |
+
+**Example:**
+
+```
+POST /api/set-home-path?path=/home/user/synced-data
+```
+
+---
+
+## GUI routes
+
+These routes are served by the same HTTP server but are not part of the JSON API.
+
+### `GET /` — Web GUI
+
+Renders the Synche single-page UI as an HTML page.  The template receives the current application state as template variables:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `dirs` | list of strings | Currently configured sync directory names |
+| `hostname` | string | Local machine hostname |
+| `local_id` | UUID string | Persistent device identifier |
+| `peers` | list of peer objects | Currently connected peers |
+| `local_ip` | IP address string | Local network IP address |
+| `home_path` | string | Absolute path of the current home directory |
+
+| Status | Meaning |
+|--------|---------|
+| `200 OK` | Page rendered successfully |
+| `500 Internal Server Error` | Template rendering failed |
+
+### `GET /static/*` — Static assets
+
+Serves CSS, JavaScript, and other static files from `gui/static/`.  Returns `404 Not Found` if the requested file does not exist.
+
+---
+
+## Server-Sent Events
+
+All events are JSON-serialized variants of the `ServerEvent` enum ([`app/src/domain/sse.rs`](../app/src/domain/sse.rs)).
+
+### `PeerConnected`
+
+A new peer was discovered on the network, or an existing peer reconnected.
+
+```json
+{
+  "PeerConnected": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "addr": "192.168.1.42",
+    "hostname": "laptop"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID string | Persistent device identifier (`local_id`) |
+| `addr` | IP address string | IPv4 address of the peer |
+| `hostname` | string | Peer hostname (`.local` suffix stripped) |
+
+### `PeerDisconnected`
+
+A peer timed out or was explicitly evicted.
+
+```json
+{
+  "PeerDisconnected": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+The inner value is the UUID (`local_id`) of the disconnected peer.
+
+### `SyncDirectoryAdded`
+
+A sync directory was added to the local configuration.
+
+```json
+{
+  "SyncDirectoryAdded": "Photos"
+}
+```
+
+The inner value is the directory name relative to `home_path`.
+
+### `SyncDirectoryRemoved`
+
+A sync directory was removed from the local configuration.
+
+```json
+{
+  "SyncDirectoryRemoved": "Archive"
+}
+```
+
+The inner value is the directory name relative to `home_path`.
+
+### `ServerRestart`
+
+The server is about to perform an in-process restart (e.g. after a `home_path` change).  Clients should reconnect to `/api/events` after receiving this event.
+
+```json
+{
+  "ServerRestart": null
+}
+```
+
+---
+
+## Data types
+
+### `RelativePath`
+
+A string path relative to `home_path`.  Always uses forward slashes `/` as separators regardless of the host OS.  Validated to exclude absolute paths, `..` traversal components, empty strings, and backslash-separated paths received from peers.
+
+### `config.toml` format
+
+The persistent configuration written by the API endpoints:
+
+```toml
+home_path = "/path/to/sync/home"
+
+[[directory]]
+name = "Photos"
+
+[[directory]]
+name = "Documents"
+```
+
+---
+
+## Route summary
+
+| Route | Method | Query params | Status codes |
+|-------|--------|--------------|-------------|
+| `/api/events` | GET | — | 200 (SSE stream) |
+| `/api/add-sync-dir` | POST | `name` | 201, 409, 500 |
+| `/api/remove-sync-dir` | POST | `name` | 200, 500 |
+| `/api/set-home-path` | POST | `path` | 200, 400, 500 |
+| `/` | GET | — | 200, 500 |
+| `/static/*` | GET | — | 200, 404 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,246 @@
+# Architecture Guide
+
+This document describes the sync engine internals: the hexagonal layer structure, conflict resolution via version vectors, the TCP wire format, the `home_path` restart contract, and mDNS peer discovery.
+
+---
+
+## Hexagonal Architecture Layout
+
+Synche follows a **ports-and-adapters** (hexagonal) layout.  The three layers have a strict one-way dependency: `domain` ← `application` ← `infra`.  No layer may reach across or skip a boundary.
+
+```
+app/src/
+├── domain/          ← pure types, no I/O, no async
+├── application/     ← services + port traits
+└── infra/           ← concrete adapters
+```
+
+### `domain/`
+
+Pure Rust types with no I/O and no async.  The full domain surface is re-exported from [`app/src/domain/mod.rs`](../app/src/domain/mod.rs):
+
+- `Config`, `SyncDirectory`, `AppPorts`
+- `Peer`
+- `EntryInfo`, `EntryKind`, `VersionVector`, `VersionCmp`
+- `CanonicalPath`, `RelativePath`
+- `ServerEvent`
+- `TransportData`, `TransportEvent`, `TransportMetadata`, `HandshakeData`
+- Channel helpers: `BroadcastChannel`, `MutexChannel`
+
+### `application/`
+
+Services and the **port traits** they depend on.  Each subsystem defines its trait in an `interface.rs`:
+
+| Trait | Location |
+|-------|----------|
+| `FileWatcherInterface` | [`application/watcher/interface.rs`](../app/src/application/watcher/interface.rs) |
+| `TransportInterface` | [`application/network/transport/interface.rs`](../app/src/application/network/transport/interface.rs) |
+| `PresenceInterface` | [`application/network/presence/interface.rs`](../app/src/application/network/presence/interface.rs) |
+| `PersistenceInterface` | [`application/persistence/interface.rs`](../app/src/application/persistence/interface.rs) |
+
+The services that consume those ports are `FileWatcher`, `TransportService`, `PresenceService`, `EntryManager`, and `PeerManager`.  The top-level orchestrator is `Synchronizer` ([`application/sync.rs`](../app/src/application/sync.rs)).
+
+### `infra/`
+
+Concrete adapters wired up in `Synchronizer::new_default()`:
+
+| Adapter | Port satisfied | Source |
+|---------|---------------|--------|
+| `NotifyFileWatcher` | `FileWatcherInterface` | [`infra/watcher/notify.rs`](../app/src/infra/watcher/notify.rs) |
+| `MdnsAdapter` | `PresenceInterface` | [`infra/network/mdns.rs`](../app/src/infra/network/mdns.rs) |
+| `TcpAdapter` | `TransportInterface` | [`infra/network/tcp/`](../app/src/infra/network/tcp/) |
+| `SqliteDb` | `PersistenceInterface` | [`infra/persistence/sqlite.rs`](../app/src/infra/persistence/sqlite.rs) |
+| HTTP server | (GUI + API) | [`infra/http/`](../app/src/infra/http/) |
+
+### Runtime wiring
+
+`AppState` ([`application/state/app_state.rs`](../app/src/application/state/app_state.rs)) is an `Arc<AppState>` shared across all tasks.  It carries device IDs, the peer map, the sync-dir map, port numbers, `home_path`, the local IP, and the SSE broadcast channel.
+
+`Synchronizer::run` joins four concurrent tasks via `tokio::select!`: transport service, presence service, file watcher, and HTTP server.
+
+---
+
+## Version Vectors and Conflict Resolution
+
+> **Source:** [`app/src/domain/entry/version.rs`](../app/src/domain/entry/version.rs) · [`app/src/application/entry_manager.rs`](../app/src/application/entry_manager.rs)
+
+### VersionVector
+
+```rust
+pub type VersionVector = HashMap<Uuid, u64>;
+```
+
+A `VersionVector` maps each device's persistent `local_id` (UUID) to a monotonically increasing counter.  The counter is bumped every time a device makes a local change to an entry.
+
+### VersionCmp
+
+Comparing two `EntryInfo` values yields one of four outcomes:
+
+| Variant | Meaning |
+|---------|---------|
+| `Equal` | Same kind and same hash — nothing to do |
+| `KeepSelf` | Local version strictly dominates remote; discard the remote entry |
+| `KeepOther` | Remote version strictly dominates local; adopt the remote entry |
+| `Conflict` | Concurrent edits on both sides — neither dominates; preserve both |
+
+The comparison iterates over the union of all device keys in both vectors.  If local counters are strictly greater on every key → `KeepSelf`; strictly lower → `KeepOther`; mixed → `Conflict`.
+
+### Conflict materialization
+
+`Conflict` is not an error — it means both sides have valid but diverging histories.  The `EntryManager` resolves conflicts deterministically:
+
+1. **Removed vs. live:** The live (non-removed) side always wins.  If both are removed the result is `Equal`.
+2. **Both live — tiebreak:** The device with the **lower UUID** keeps its version.  The other device copies its local file to a conflict file and then accepts the winner's bytes.
+
+**Conflict file naming:**
+
+```
+<stem>_CONFLICT_<unix_epoch_seconds>_<device_uuid>.<ext>
+```
+
+Example: `report_CONFLICT_1716864000_a1b2c3d4-e5f6-47g8-h9i0-j1k2l3m4n5o6.md`
+
+This naming ensures no data is lost and the conflict file is unambiguously associated with the device that created it.
+
+### Deletion sentinel
+
+Deleted entries are not removed from the metadata store.  Instead, their `hash` field is set to the 32-character all-zeros string `"00000000000000000000000000000000"` (`REMOVED_HASH`).  This sentinel allows the version vector to keep propagating the deletion to peers that missed it.
+
+---
+
+## TCP Wire Format
+
+> **Source:** [`app/src/infra/network/tcp/`](../app/src/infra/network/tcp/)
+
+Every peer-to-peer message uses the same framing.  The sender opens a fresh TCP connection for each message.
+
+### Frame layout
+
+```
+Bytes  0–15   Source device UUID (16 raw bytes, big-endian UUID representation)
+Byte   16     Kind tag (1 byte, see table below)
+Bytes  17–20  Payload length L (u32 big-endian)
+Bytes  21–    JSON payload (L bytes)
+
+--- Transfer frames only ---
+Bytes  21+L – 21+L+7   File size S (u64 big-endian)
+Bytes  21+L+8 –        Raw file data (exactly S bytes, streamed in 1 MiB chunks)
+```
+
+### Kind tags
+
+| Value | Variant | Payload type |
+|-------|---------|--------------|
+| `1` | `HandshakeSyn` | `HandshakeData` (JSON) |
+| `2` | `HandshakeAck` | `HandshakeData` (JSON) |
+| `3` | `Metadata` | `EntryInfo` (JSON) |
+| `4` | `Request` | `EntryInfo` (JSON) |
+| `5` | `Transfer` | `EntryInfo` (JSON) + raw file bytes |
+
+The discriminants are part of the wire format — changing them would break compatibility with older peers.
+
+### Handshake flow
+
+When a peer is first discovered via mDNS, the local device opens a TCP connection and sends a `HandshakeSyn`.  The peer replies with a `HandshakeAck` on a new outbound connection.  Both messages carry a `HandshakeData` payload:
+
+```json
+{
+  "hostname": "laptop",
+  "instance_id": "<per-process UUID>",
+  "sync_dirs": [{ "name": "Photos" }],
+  "entries": {
+    "Photos/vacation.jpg": { "name": "Photos/vacation.jpg", "kind": "File", "hash": "abc123...", "version": { "<uuid>": 3 } }
+  }
+}
+```
+
+After the handshake, each side compares the received entry map against its own and requests any entries where the peer's version dominates.
+
+### Metadata and Request messages
+
+Both use the short frame (no file bytes):
+
+- **Metadata** — unidirectional announcement of an `EntryInfo` change, broadcast to all peers after any local file event.
+- **Request** — asks the target peer to send a `Transfer` for the named entry.
+
+### Chunked file transfer
+
+`Transfer` frames stream file bytes in **1 MiB chunks** (constant `TRANSFER_CHUNK_SIZE = 1024 * 1024`) with a streaming SHA-256 computed over the bytes actually sent.  The maximum supported transfer size is **16 GiB** (`MAX_TRANSFER_SIZE = 16 * 1024 * 1024 * 1024`).
+
+If the source file shrinks during streaming the remaining bytes are zero-padded so the wire size matches the advertised `S`.  The hash will diverge and the receiver rejects the transfer by hash mismatch.
+
+### Error handling
+
+Errors that occur **after** a connection is accepted (corrupt payload, truncated stream, malformed JSON) are logged and skipped — they do not stop the synchronizer.  Listener bind and accept failures remain fatal.
+
+---
+
+## `home_path` Change → Restart Sentinel Contract
+
+> **Source:** [`app/src/application/sync.rs`](../app/src/application/sync.rs)
+
+Changing `home_path` via [`POST /api/set-home-path`](API.md#post-apiset-home-path) writes the new value to `config.toml` and then signals the synchronizer to rebuild by propagating a sentinel `io::Error`:
+
+```
+HOME_PATH_CHANGED:<old_path>:<new_path>
+```
+
+### Restart flow
+
+1. The API handler calls `AppState::set_home_path_in_config()`, which writes the config and returns the sentinel error.
+2. The sentinel bubbles up through `Synchronizer::_run()` and is caught by `Synchronizer::run()`.
+3. Before returning the error, `run()` broadcasts a `ServerRestart` SSE event (allowing the GUI to reconnect) and then shuts down the current synchronizer instance.
+4. `run_default_with_restart()` receives the sentinel, logs the path change, and re-enters the loop to build a new `Synchronizer` with the updated configuration.
+5. The OS process is **not** restarted — only the in-process synchronizer is rebuilt.
+
+### Parsing
+
+The sentinel is parsed with `split_once(':')` so that colons in the new path (e.g. Windows drive letters like `C:\Users\...`) are preserved correctly.
+
+### Contract
+
+Any code that touches the shutdown or restart path **must not** swallow, modify, or re-wrap this sentinel error.  Only `run_default_with_restart` may consume it.
+
+---
+
+## mDNS Peer Discovery
+
+> **Source:** [`app/src/infra/network/mdns.rs`](../app/src/infra/network/mdns.rs)
+
+Synche uses multicast DNS (mDNS) for zero-configuration peer discovery on the local network.
+
+### Service type
+
+```
+_synche._udp.local.
+```
+
+### Service advertisement
+
+Each device registers itself as:
+
+```
+<local_id>._synche._udp.local.
+```
+
+where `<local_id>` is the persistent device UUID.  The registration includes:
+
+- **Host:** `<hostname>.local.`
+- **Address:** local IPv4 address (IPv6 is disabled)
+- **Port:** presence port (default **42881**)
+- **TXT property `instance_id`:** a per-process UUID generated fresh on each startup
+
+### Peer discovery loop
+
+The `MdnsAdapter` browses for `_synche._udp.local.` records and converts `ServiceEvent`s into `PresenceEvent`s:
+
+| `ServiceEvent` | `PresenceEvent` |
+|----------------|-----------------|
+| `ServiceResolved` | `Ping { id, addr, instance_id }` |
+| `ServiceRemoved` | `Leave { id }` |
+
+Loopback addresses and the device's own `local_id` are filtered out.
+
+### Restart detection
+
+Because `instance_id` changes on every process start, a peer that re-advertises with a different `instance_id` is treated as a fresh connection.  This ensures that a peer's handshake is repeated after it restarts even if its `local_id` (and therefore its mDNS service name) stays the same.


### PR DESCRIPTION
Closes #27.

## What this adds

### `docs/API.md` — HTTP endpoint reference
- `GET /api/events` (SSE) with all five `ServerEvent` JSON shapes
- `POST /api/add-sync-dir` — query params, status codes (201/409/500)
- `POST /api/remove-sync-dir` — idempotent, status codes (200/500)
- `POST /api/set-home-path` — validation notes, restart sentinel link, status codes (200/400/500)
- GUI routes (`GET /`, `GET /static/*`) with template variables
- `RelativePath` type, `config.toml` format, and a route summary table

### `docs/ARCHITECTURE.md` — Sync engine reference
- Hexagonal layout with layer dependency rule and adapter table
- Version vectors (`VersionVector`, `VersionCmp` variants, conflict tiebreak, conflict file naming, deletion sentinel)
- TCP wire format: byte-level frame table, kind tag table, handshake flow, chunked transfer (1 MiB chunks, SHA-256, 16 GiB max)
- `home_path` restart sentinel contract (format, flow, parsing, contract rules)
- mDNS discovery (service type, advertisement, discovery loop, restart detection via `instance_id`)

### `README.md`
- New **Documentation** section with links to both new docs

## Checklist
- [x] `cargo clippy -p synche -- -D warnings` — clean
- [x] `cargo test -p synche` — 128 passed, 0 failed