### PR TITLE
feat: expandable peer detail panel (instance ID, last seen, sync dirs)

### DIFF
--- a/app/src/application/state/peer_manager.rs
+++ b/app/src/application/state/peer_manager.rs
@@ -31,6 +31,13 @@ impl PeerManager {
                 id: peer.id,
                 addr: peer.addr,
                 hostname: peer.hostname.clone(),
+                instance_id: peer.instance_id,
+                last_seen: peer
+                    .last_seen
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                sync_dirs: peer.sync_dirs.keys().cloned().collect(),
             })
             .await;
         }
@@ -277,5 +284,32 @@ mod tests {
 
         let recipients = pm.get_peers_to_send_metadata(&entry).await;
         assert_eq!(recipients, vec![sharing]);
+    }
+
+    #[tokio::test]
+    async fn peer_connected_event_includes_instance_last_seen_and_dirs() {
+        let (_env, pm, mut rx) = setup().await;
+        let id = Uuid::new_v4();
+        let instance = Uuid::new_v4();
+        let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 10));
+
+        pm.insert(peer(id, instance, addr, vec!["Docs"])).await;
+
+        let event = rx.try_recv().unwrap();
+        if let ServerEvent::PeerConnected {
+            id: ev_id,
+            instance_id,
+            last_seen,
+            sync_dirs,
+            ..
+        } = event
+        {
+            assert_eq!(ev_id, id);
+            assert_eq!(instance_id, instance);
+            assert!(last_seen > 0);
+            assert_eq!(sync_dirs, vec![RelativePath::from("Docs")]);
+        } else {
+            panic!("expected PeerConnected");
+        }
     }
 }

--- a/app/src/domain/sse.rs
+++ b/app/src/domain/sse.rs
@@ -13,6 +13,12 @@ pub enum ServerEvent {
         id: Uuid,
         addr: IpAddr,
         hostname: String,
+        /// Regenerated on every process start; a change signals a peer restart.
+        instance_id: Uuid,
+        /// Seconds since UNIX epoch — when the peer last announced itself.
+        last_seen: u64,
+        /// Names of the sync directories this peer is sharing.
+        sync_dirs: Vec<RelativePath>,
     },
     /// A peer was evicted (timed out, or explicitly disconnected).
     PeerDisconnected(Uuid),

--- a/docs/API.md
+++ b/docs/API.md
@@ -142,7 +142,10 @@ A new peer was discovered on the network, or an existing peer reconnected.
   "PeerConnected": {
     "id": "550e8400-e29b-41d4-a716-446655440000",
     "addr": "192.168.1.42",
-    "hostname": "laptop"
+    "hostname": "laptop",
+    "instance_id": "7b3f9c1a-2d4e-4f5a-b6c7-d8e9f0a1b2c3",
+    "last_seen": 1748390400,
+    "sync_dirs": ["Documents", "Photos"]
   }
 }
 ```
@@ -152,6 +155,9 @@ A new peer was discovered on the network, or an existing peer reconnected.
 | `id` | UUID string | Persistent device identifier (`local_id`) |
 | `addr` | IP address string | IPv4 address of the peer |
 | `hostname` | string | Peer hostname (`.local` suffix stripped) |
+| `instance_id` | UUID string | Regenerated on every process start; a change signals a peer restart |
+| `last_seen` | integer | UNIX timestamp (seconds) of the peer's most recent presence announcement |
+| `sync_dirs` | array of strings | Names of the sync directories this peer is sharing (relative to its home path) |
 
 ### `PeerDisconnected`
 

--- a/gui/index.html
+++ b/gui/index.html
@@ -166,6 +166,22 @@
                         </summary>
                         <p><strong>IP:</strong> {{ peer.addr }}</p>
                         <p><strong>ID:</strong> {{ peer.id }}</p>
+                        <p><strong>Instance ID:</strong> {{ peer.instance_id }}</p>
+                        <p>
+                            <strong>Last Seen:</strong>
+                            <span class="peer-last-seen" data-ts="{{ peer.last_seen.secs_since_epoch }}"></span>
+                        </p>
+                        <p><strong>Sync Directories:</strong>
+                            {% if peer.sync_dirs %}
+                                <ul>
+                                    {% for dir_name, _ in peer.sync_dirs %}
+                                        <li>{{ dir_name }}</li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                None
+                            {% endif %}
+                        </p>
                     </details>
                     {% endfor %}
                 </div>
@@ -409,5 +425,11 @@
 
         <script type="module" src="/static/main.js"></script>
         <script type="module" src="/static/sse.js"></script>
+        <script>
+            document.querySelectorAll(".peer-last-seen[data-ts]").forEach(function (el) {
+                var ts = parseInt(el.dataset.ts, 10);
+                if (ts) el.textContent = new Date(ts * 1000).toLocaleString();
+            });
+        </script>
     </body>
 </html>

--- a/gui/static/components.js
+++ b/gui/static/components.js
@@ -1,3 +1,17 @@
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[c],
+  );
+}
+
 export function dirListItem(name) {
   return `<details class="list-item" id="dir-${name}">
             <summary>
@@ -44,7 +58,7 @@ export function peerListItem({ id, addr, hostname, instance_id, last_seen, sync_
     : "unknown";
   const dirsList =
     sync_dirs && sync_dirs.length
-      ? `<ul>${sync_dirs.map((d) => `<li>${d}</li>`).join("")}</ul>`
+      ? `<ul>${sync_dirs.map((d) => `<li>${escapeHtml(d)}</li>`).join("")}</ul>`
       : "None";
 
   return `<details class="list-item" id="peer-${id}">

--- a/gui/static/components.js
+++ b/gui/static/components.js
@@ -38,7 +38,15 @@ export function dirListItem(name) {
           </details>`;
 }
 
-export function peerListItem({ id, addr, hostname }) {
+export function peerListItem({ id, addr, hostname, instance_id, last_seen, sync_dirs }) {
+  const tsLabel = last_seen
+    ? new Date(last_seen * 1000).toLocaleString()
+    : "unknown";
+  const dirsList =
+    sync_dirs && sync_dirs.length
+      ? `<ul>${sync_dirs.map((d) => `<li>${d}</li>`).join("")}</ul>`
+      : "None";
+
   return `<details class="list-item" id="peer-${id}">
             <summary><strong><svg class="lucide lucide-laptop-minimal-icon lucide-laptop-minimal" fill="none" height="20" stroke="currentColor" stroke-linecap="round"
                                  stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="20"
@@ -58,6 +66,9 @@ export function peerListItem({ id, addr, hostname }) {
                 </small></summary>
             <p><strong>IP:</strong> ${addr}</p>
             <p><strong>ID:</strong> ${id}</p>
+            <p><strong>Instance ID:</strong> ${instance_id ?? "unknown"}</p>
+            <p><strong>Last Seen:</strong> ${tsLabel}</p>
+            <p><strong>Sync Directories:</strong> ${dirsList}</p>
           </details>`;
 }
 


### PR DESCRIPTION
Closes #19.

## What

Adds the expanded peer-card detail panel requested in #19. Clicking a peer card (which already used `<details>`/`<summary>`) now reveals three additional rows alongside the existing IP and device ID:

- **Instance ID** — the `instance_id` UUID (regenerated each process start; lets you spot restarts)
- **Last Seen** — human-readable local timestamp of the peer's most recent presence announcement
- **Sync Directories** — list of directory names the peer is sharing

## How

### Backend (`ServerEvent::PeerConnected`)

`PeerConnected` was a minimal 3-field variant (id, addr, hostname). Three fields are added:

| Field | Type | Notes |
|-------|------|-------|
| `instance_id` | `Uuid` | already on `Peer`, forwarded as-is |
| `last_seen` | `u64` | UNIX epoch seconds — easy for JS: `new Date(ts * 1000)` |
| `sync_dirs` | `Vec<RelativePath>` | keys of `peer.sync_dirs` HashMap; only names needed |

`PeerManager::insert()` is updated to populate them. All existing tests use `{ id, .. }` destructuring and continue to compile and pass.

### Frontend

- **`gui/static/components.js`** — `peerListItem()` now destructures and renders the three new fields; timestamp is formatted inline with `new Date(ts * 1000).toLocaleString()`.
- **`gui/index.html`** — Jinja template extended with the same three rows for peers present on page load (`peer.last_seen.secs_since_epoch` from the serde-serialised `SystemTime`, iterated `sync_dirs` HashMap). A tiny inline `<script>` at the bottom of `<body>` formats all `data-ts` spans on load, keeping the static and SSE-driven paths visually identical.
- **`docs/API.md`** — `PeerConnected` JSON example and field table updated.

## Tests

- New test `peer_connected_event_includes_instance_last_seen_and_dirs` in `peer_manager.rs` asserts all three fields are non-default and match the inserted peer.
- 129/129 tests pass, zero Clippy warnings.