### PR TITLE
feat: live per-directory sync activity in GUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Never construct a production `AppState` from a test (the binary builds it via `S
 
 ### Frontend
 
-`gui/index.html` is a single-page UI rendered via `minijinja` and served by axum; static assets in `gui/static/`. The server pushes live updates to the GUI over SSE using `ServerEvent` broadcast through `AppState::sse_sender()`.
+`gui/index.html` is a single-page UI rendered via `minijinja` and served by axum; static assets in `gui/static/`. The server pushes live updates to the GUI over SSE using `ServerEvent` broadcast through `AppState::sse_sender()`. Variants currently include peer connect/disconnect, sync-directory add/remove, `ServerRestart`, and the per-entry `EntrySyncStarted` / `EntrySyncCompleted` / `EntrySyncFailed` events broadcast from the transport receiver path so the GUI can show live per-directory sync activity.
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 -   **Automatic Discovery:** Devices running Synche on the same network find each other automatically using mDNS.
 -   **.gitignore Support:** Respects your `.gitignore` files, plus `.git/` directories are always excluded — safe to sync folders containing Git repositories.
 -   **Real-Time Sync:** Uses a file watcher to detect changes and synchronize them instantly.
+-   **Live Activity Feedback:** The web GUI shows per-directory sync activity as files are received from peers, including the most recent completed and failed transfers.
 -   **Peer-to-Peer:** Files are transferred directly between your devices.
 -   **Web Interface:** A simple, browser-based GUI for managing the app.
 

--- a/app/src/application/network/transport/receiver.rs
+++ b/app/src/application/network/transport/receiver.rs
@@ -4,8 +4,8 @@ use crate::{
         persistence::interface::PersistenceInterface,
     },
     domain::{
-        EntryInfo, MutexChannel, Peer, TransportChannelData, TransportData, TransportEvent,
-        VersionCmp,
+        EntryInfo, MutexChannel, Peer, ServerEvent, TransportChannelData, TransportData,
+        TransportEvent, VersionCmp,
     },
     utils::fs::is_git_path,
 };
@@ -13,6 +13,7 @@ use futures::TryFutureExt;
 use std::{net::IpAddr, sync::Arc};
 use tokio::{fs, io, sync::mpsc::Sender};
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 /// Inbound side of the transport service.
 ///
@@ -152,6 +153,7 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
 
         for entry in entries_to_request {
             if entry.is_file() {
+                self.broadcast_sync_started(event.metadata.source_id, &entry);
                 self.send_tx
                     .send(TransportChannelData::Request((peer.addr, entry)))
                     .await
@@ -183,6 +185,7 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
                 if peer_entry.is_removed() {
                     self.remove_entry(&peer_entry.name).await
                 } else if peer_entry.is_file() {
+                    self.broadcast_sync_started(event.metadata.source_id, &peer_entry);
                     self.send_tx
                         .send(TransportChannelData::Request((
                             event.metadata.source_ip,
@@ -241,10 +244,31 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
 
         let entry = self.entry_manager.insert_entry(received_entry).await?;
 
+        self.broadcast_sync_completed(event.metadata.source_id, &entry);
+
         self.send_tx
             .send(TransportChannelData::Metadata(entry))
             .await
             .map_err(io::Error::other)
+    }
+
+    fn broadcast_sync_started(&self, peer: Uuid, entry: &EntryInfo) {
+        let _ = self.state.sse_sender().send(ServerEvent::EntrySyncStarted {
+            dir: entry.get_sync_dir(),
+            relative_path: entry.name.clone(),
+            peer,
+        });
+    }
+
+    fn broadcast_sync_completed(&self, peer: Uuid, entry: &EntryInfo) {
+        let _ = self
+            .state
+            .sse_sender()
+            .send(ServerEvent::EntrySyncCompleted {
+                dir: entry.get_sync_dir(),
+                relative_path: entry.name.clone(),
+                peer,
+            });
     }
 
     async fn create_received_dir(&self, dir: EntryInfo) -> io::Result<()> {
@@ -384,5 +408,81 @@ mod tests {
                 .is_none()
         );
         assert!(matches!(send_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    fn file_entry(name: &str) -> EntryInfo {
+        EntryInfo {
+            name: name.into(),
+            kind: EntryKind::File,
+            hash: Some("hash".to_string()),
+            version: HashMap::from([(Uuid::new_v4(), 1)]),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_transfer_emits_sync_completed_after_insert() {
+        let (env, receiver, _entry_manager, _send_rx) = setup().await;
+        let mut sse_rx = env.state.sse_subscribe();
+        let peer = Uuid::new_v4();
+        let entry = file_entry("sync/payload.bin");
+
+        let evt = TransportEvent {
+            payload: TransportData::Transfer(entry.clone()),
+            metadata: TransportMetadata {
+                source_id: peer,
+                source_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            },
+        };
+        receiver.handle_transfer(evt).await.unwrap();
+
+        match sse_rx.try_recv().expect("expected EntrySyncCompleted") {
+            ServerEvent::EntrySyncCompleted {
+                dir,
+                relative_path,
+                peer: emitted_peer,
+            } => {
+                assert_eq!(dir.as_ref() as &str, "sync");
+                assert_eq!(relative_path, entry.name);
+                assert_eq!(emitted_peer, peer);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_metadata_emits_sync_started_when_keep_other_file() {
+        let (env, receiver, _entry_manager, _send_rx) = setup().await;
+        let mut sse_rx = env.state.sse_subscribe();
+        let peer = Uuid::new_v4();
+        // Peer entry has a version on its own device id — nothing locally,
+        // so handle_metadata yields KeepOther and enqueues a Request.
+        let entry = EntryInfo {
+            name: "sync/payload.bin".into(),
+            kind: EntryKind::File,
+            hash: Some("hash".to_string()),
+            version: HashMap::from([(peer, 1)]),
+        };
+
+        let evt = TransportEvent {
+            payload: TransportData::Metadata(entry.clone()),
+            metadata: TransportMetadata {
+                source_id: peer,
+                source_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            },
+        };
+        receiver.handle_metadata(evt).await.unwrap();
+
+        match sse_rx.try_recv().expect("expected EntrySyncStarted") {
+            ServerEvent::EntrySyncStarted {
+                dir,
+                relative_path,
+                peer: emitted_peer,
+            } => {
+                assert_eq!(dir.as_ref() as &str, "sync");
+                assert_eq!(relative_path, entry.name);
+                assert_eq!(emitted_peer, peer);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 }

--- a/app/src/domain/sse.rs
+++ b/app/src/domain/sse.rs
@@ -26,7 +26,61 @@ pub enum ServerEvent {
     SyncDirectoryAdded(RelativePath),
     /// A sync directory was removed from the local config.
     SyncDirectoryRemoved(RelativePath),
+    /// This device started receiving an entry from a peer.
+    EntrySyncStarted {
+        /// Top-level sync directory the entry belongs to.
+        dir: RelativePath,
+        /// Full path inside the home directory.
+        relative_path: RelativePath,
+        /// Peer the entry is being received from.
+        peer: Uuid,
+    },
+    /// An entry finished syncing and was applied to disk.
+    EntrySyncCompleted {
+        dir: RelativePath,
+        relative_path: RelativePath,
+        peer: Uuid,
+    },
+    /// An entry sync was aborted mid-transfer.
+    EntrySyncFailed {
+        dir: RelativePath,
+        relative_path: RelativePath,
+        peer: Uuid,
+        /// Human-readable failure reason (hash mismatch, oversized, I/O error).
+        reason: String,
+    },
     /// The server is restarting (e.g. after a `home_path` change) — the
     /// GUI should reconnect.
     ServerRestart,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_sync_variants_serialize_as_tagged_json() {
+        let peer = Uuid::nil();
+        let started = ServerEvent::EntrySyncStarted {
+            dir: "sync".into(),
+            relative_path: "sync/foo.txt".into(),
+            peer,
+        };
+        let started_json = serde_json::to_value(&started).unwrap();
+        assert_eq!(started_json["EntrySyncStarted"]["dir"], "sync");
+        assert_eq!(
+            started_json["EntrySyncStarted"]["relative_path"],
+            "sync/foo.txt"
+        );
+        assert_eq!(started_json["EntrySyncStarted"]["peer"], peer.to_string());
+
+        let failed = ServerEvent::EntrySyncFailed {
+            dir: "sync".into(),
+            relative_path: "sync/foo.txt".into(),
+            peer,
+            reason: "Hash mismatch".into(),
+        };
+        let failed_json = serde_json::to_value(&failed).unwrap();
+        assert_eq!(failed_json["EntrySyncFailed"]["reason"], "Hash mismatch");
+    }
 }

--- a/app/src/infra/network/tcp/adapter.rs
+++ b/app/src/infra/network/tcp/adapter.rs
@@ -60,7 +60,7 @@ impl TransportInterface for TcpAdapter {
                 stream.read_exact(&mut kind_buf).await?;
                 let kind = TcpStreamKind::try_from(kind_buf[0])?;
 
-                let payload = self.receiver.read_data(stream, kind).await?;
+                let payload = self.receiver.read_data(stream, kind, source_id).await?;
 
                 Ok(TransportEvent {
                     metadata: TransportMetadata {

--- a/app/src/infra/network/tcp/receiver.rs
+++ b/app/src/infra/network/tcp/receiver.rs
@@ -1,7 +1,10 @@
 use crate::{
     application::AppState,
     application::network::transport::interface::{TransportError, TransportResult},
-    domain::{EntryInfo, EntryKind, HandshakeData, RelativePath, SyncDirectory, TransportData},
+    domain::{
+        EntryInfo, EntryKind, HandshakeData, RelativePath, ServerEvent, SyncDirectory,
+        TransportData,
+    },
     infra::network::tcp::{
         chunk::{MAX_TRANSFER_SIZE, TRANSFER_CHUNK_SIZE},
         kind::TcpStreamKind,
@@ -44,13 +47,14 @@ impl TcpReceiver {
         &self,
         mut stream: TcpStream,
         kind: TcpStreamKind,
+        source_id: Uuid,
     ) -> TransportResult<TransportData> {
         match kind {
             TcpStreamKind::HandshakeSyn => self.read_handshake(&mut stream, true).await,
             TcpStreamKind::HandshakeAck => self.read_handshake(&mut stream, false).await,
             TcpStreamKind::Metadata => self.read_metadata(&mut stream).await,
             TcpStreamKind::Request => self.read_request(&mut stream).await,
-            TcpStreamKind::Transfer => self.read_transfer(&mut stream).await,
+            TcpStreamKind::Transfer => self.read_transfer(&mut stream, source_id).await,
         }
     }
 
@@ -88,9 +92,30 @@ impl TcpReceiver {
         Ok(TransportData::Request(entry))
     }
 
-    async fn read_transfer(&self, stream: &mut TcpStream) -> TransportResult<TransportData> {
+    async fn read_transfer(
+        &self,
+        stream: &mut TcpStream,
+        source_id: Uuid,
+    ) -> TransportResult<TransportData> {
         let entry = self.read_entry_info(stream).await?;
 
+        // Header parsed — any failure from here on can be attributed to this
+        // specific entry, so emit `EntrySyncFailed` before propagating the
+        // error (the adapter then swallows the error itself).
+        match self.read_transfer_after_header(stream, &entry).await {
+            Ok(()) => Ok(TransportData::Transfer(entry)),
+            Err(err) => {
+                self.broadcast_sync_failed(source_id, &entry, &err);
+                Err(err)
+            }
+        }
+    }
+
+    async fn read_transfer_after_header(
+        &self,
+        stream: &mut TcpStream,
+        entry: &EntryInfo,
+    ) -> TransportResult<()> {
         let mut entry_size_buf = [0u8; 8];
         stream.read_exact(&mut entry_size_buf).await?;
         let entry_size = u64::from_be_bytes(entry_size_buf);
@@ -104,10 +129,10 @@ impl TcpReceiver {
         if is_git_path(&entry.name) {
             // Drain the payload from the wire without writing to disk.
             Self::discard_bytes(stream, entry_size, TRANSFER_CHUNK_SIZE).await?;
-            return Ok(TransportData::Transfer(entry));
+            return Ok(());
         }
 
-        let mut staging = self.create_staging(&entry).await?;
+        let mut staging = self.create_staging(entry).await?;
 
         let computed_hash =
             match Self::stream_to_file(stream, &mut staging.file, entry_size, TRANSFER_CHUNK_SIZE)
@@ -131,9 +156,17 @@ impl TcpReceiver {
             ));
         }
 
-        self.finalise_staging(&entry, staging).await?;
+        self.finalise_staging(entry, staging).await
+    }
 
-        Ok(TransportData::Transfer(entry))
+    fn broadcast_sync_failed(&self, peer: Uuid, entry: &EntryInfo, err: &TransportError) {
+        let TransportError::Failure(reason) = err;
+        let _ = self.state.sse_sender().send(ServerEvent::EntrySyncFailed {
+            dir: entry.name.sync_dir(),
+            relative_path: entry.name.clone(),
+            peer,
+            reason: reason.clone(),
+        });
     }
 
     async fn read_entry_info(&self, stream: &mut TcpStream) -> TransportResult<EntryInfo> {
@@ -447,7 +480,9 @@ mod tests {
 
         let (stream, _) = listener.accept().await.unwrap();
         let receiver = TcpReceiver::new(state.clone());
-        let data = ok(receiver.read_data(stream, TcpStreamKind::Transfer).await);
+        let data = ok(receiver
+            .read_data(stream, TcpStreamKind::Transfer, Uuid::new_v4())
+            .await);
         writer.await.unwrap();
 
         assert!(matches!(data, TransportData::Transfer(_)));
@@ -463,11 +498,13 @@ mod tests {
     async fn read_transfer_rejects_hash_mismatch_and_cleans_staging() {
         let env = crate::utils::test_support::test_env().await;
         let state = env.state.clone();
+        let mut sse_rx = state.sse_subscribe();
         let root = format!("tcp_chunk_bad_{}", Uuid::new_v4());
         let entry_name = format!("{root}/payload.bin");
         let original_path = state.home_path().join(&entry_name);
         let contents = vec![0xAAu8; 64];
         let entry = file_entry(&entry_name, Some("deadbeef".to_string()));
+        let peer = Uuid::new_v4();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -480,7 +517,9 @@ mod tests {
 
         let (stream, _) = listener.accept().await.unwrap();
         let receiver = TcpReceiver::new(state.clone());
-        let result = receiver.read_data(stream, TcpStreamKind::Transfer).await;
+        let result = receiver
+            .read_data(stream, TcpStreamKind::Transfer, peer)
+            .await;
         writer.await.unwrap();
 
         match result {
@@ -490,6 +529,20 @@ mod tests {
             Ok(_) => panic!("expected hash-mismatch failure"),
         }
         assert!(!original_path.exists());
+
+        match sse_rx.try_recv().expect("expected EntrySyncFailed") {
+            crate::domain::ServerEvent::EntrySyncFailed {
+                relative_path,
+                peer: emitted_peer,
+                reason,
+                ..
+            } => {
+                assert_eq!(relative_path.as_ref() as &str, entry_name);
+                assert_eq!(emitted_peer, peer);
+                assert!(reason.contains("Hash mismatch"), "reason was: {reason}");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
 
         let root_path = state.home_path().join(&root);
         if root_path.exists() {
@@ -525,7 +578,9 @@ mod tests {
 
         let (stream, _) = listener.accept().await.unwrap();
         let receiver = TcpReceiver::new(state.clone());
-        let result = receiver.read_data(stream, TcpStreamKind::Transfer).await;
+        let result = receiver
+            .read_data(stream, TcpStreamKind::Transfer, Uuid::new_v4())
+            .await;
         writer.await.unwrap();
 
         match result {
@@ -568,7 +623,9 @@ mod tests {
 
         let (stream, _) = listener.accept().await.unwrap();
         let receiver = TcpReceiver::new(state.clone());
-        let data = ok(receiver.read_data(stream, TcpStreamKind::Transfer).await);
+        let data = ok(receiver
+            .read_data(stream, TcpStreamKind::Transfer, Uuid::new_v4())
+            .await);
         writer.await.unwrap();
 
         assert!(matches!(data, TransportData::Transfer(_)));

--- a/docs/API.md
+++ b/docs/API.md
@@ -195,6 +195,64 @@ A sync directory was removed from the local configuration.
 
 The inner value is the directory name relative to `home_path`.
 
+### `EntrySyncStarted`
+
+This device has begun receiving an entry from a peer.  Emitted on every file the receiver enqueues a `Request` for (both during the handshake catch-up and when later metadata announces a newer version).
+
+```json
+{
+  "EntrySyncStarted": {
+    "dir": "Photos",
+    "relative_path": "Photos/2024/trip.jpg",
+    "peer": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dir` | `RelativePath` | Top-level sync directory the entry belongs to |
+| `relative_path` | `RelativePath` | Full path of the entry inside `home_path` |
+| `peer` | UUID string | Peer (`local_id`) the entry is being received from |
+
+### `EntrySyncCompleted`
+
+The entry finished transferring and the receiver wrote the file and persisted its metadata.
+
+```json
+{
+  "EntrySyncCompleted": {
+    "dir": "Photos",
+    "relative_path": "Photos/2024/trip.jpg",
+    "peer": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+Field semantics match `EntrySyncStarted`.
+
+### `EntrySyncFailed`
+
+A transfer was aborted mid-flight (hash mismatch, oversized payload, I/O error, or staging-finalise failure).  The peer is not evicted — the receive loop continues.
+
+```json
+{
+  "EntrySyncFailed": {
+    "dir": "Photos",
+    "relative_path": "Photos/2024/trip.jpg",
+    "peer": "550e8400-e29b-41d4-a716-446655440000",
+    "reason": "Hash mismatch: data corruption detected"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dir` | `RelativePath` | Top-level sync directory the entry belongs to |
+| `relative_path` | `RelativePath` | Full path of the entry inside `home_path` |
+| `peer` | UUID string | Peer (`local_id`) the failed transfer originated from |
+| `reason` | string | Human-readable failure reason |
+
 ### `ServerRestart`
 
 The server is about to perform an in-process restart (e.g. after a `home_path` change).  Clients should reconnect to `/api/events` after receiving this event.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,6 +185,16 @@ Changing `home_path` via [`POST /api/set-home-path`](API.md#post-apiset-home-pat
 HOME_PATH_CHANGED:<old_path>:<new_path>
 ```
 
+### Live activity events
+
+The transport receiver broadcasts per-entry SSE events as files move across the network:
+
+- `EntrySyncStarted` is emitted from `TransportReceiver` at both points where this device enqueues a `Request` (handshake catch-up and the `KeepOther` branch of `handle_metadata`).
+- `EntrySyncCompleted` is emitted after `handle_transfer` calls `insert_entry`.
+- `EntrySyncFailed` is emitted from `TcpReceiver::read_transfer` once the entry header has been parsed; the original `TransportError` is still propagated up so the receive loop logs and skips it as a bad peer message.
+
+The GUI renders these into a per-directory activity strip with a rolling history of recent completed/failed entries.  See [API.md](API.md#server-sent-events) for the wire schemas.
+
 ### Restart flow
 
 1. The API handler calls `AppState::set_home_path_in_config()`, which writes the config and returns the sentinel error.

--- a/gui/index.html
+++ b/gui/index.html
@@ -265,6 +265,8 @@
                             </strong>
                         </summary>
 
+                        <div class="dir-activity" hidden></div>
+
                         <div class="dir-actions">
                             <button class="btn icon-btn remove-dir-btn">
                                 <svg

--- a/gui/static/components.js
+++ b/gui/static/components.js
@@ -13,7 +13,8 @@ function escapeHtml(s) {
 }
 
 export function dirListItem(name) {
-  return `<details class="list-item" id="dir-${name}">
+  const safe = escapeHtml(name);
+  return `<details class="list-item" id="dir-${safe}">
             <summary>
               <strong>
                         <svg class="lucide lucide-folder-open-icon lucide-folder-open" fill="none" height="20"
@@ -22,9 +23,11 @@ export function dirListItem(name) {
                              xmlns="http://www.w3.org/2000/svg">
                             <path d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"/>
                         </svg>
-                        <span>${name}</span>
+                        <span>${safe}</span>
                     </strong>
             </summary>
+
+            <div class="dir-activity" hidden></div>
 
             <div class="dir-actions">
             <button class="btn icon-btn remove-dir-btn">
@@ -111,4 +114,100 @@ export function setPeerAsDisconnected(peer) {
   if (status) {
     status.innerHTML = peerDisconnectedStatus();
   }
+}
+
+const ACTIVITY_HISTORY_LIMIT = 5;
+
+function getActivityStrip(dir) {
+  const el = document.getElementById(`dir-${dir}`);
+  if (!el) return null;
+  let strip = el.querySelector(".dir-activity");
+  if (!strip) {
+    strip = document.createElement("div");
+    strip.className = "dir-activity";
+    strip.hidden = true;
+    el.insertBefore(strip, el.querySelector(".dir-actions") ?? null);
+  }
+  return strip;
+}
+
+function ensureActiveSlot(strip) {
+  let slot = strip.querySelector(".dir-activity-current");
+  if (!slot) {
+    slot = document.createElement("div");
+    slot.className = "dir-activity-current";
+    strip.prepend(slot);
+  }
+  return slot;
+}
+
+function ensureHistory(strip) {
+  let hist = strip.querySelector(".dir-activity-history");
+  if (!hist) {
+    hist = document.createElement("ul");
+    hist.className = "dir-activity-history";
+    strip.append(hist);
+  }
+  return hist;
+}
+
+function peerLabel(peerId) {
+  const peerEl = document.getElementById(`peer-${peerId}`);
+  const hostnameSpan = peerEl?.querySelector("summary strong span");
+  const text = hostnameSpan?.textContent?.trim();
+  return text && text.length > 0 ? text : peerId;
+}
+
+function activeKey(path, peer) {
+  return `${peer}::${path}`;
+}
+
+function pushHistory(strip, html) {
+  const hist = ensureHistory(strip);
+  const item = document.createElement("li");
+  item.innerHTML = html;
+  hist.prepend(item);
+  while (hist.children.length > ACTIVITY_HISTORY_LIMIT) {
+    hist.removeChild(hist.lastChild);
+  }
+}
+
+export function setSyncStarted({ dir, relative_path, peer }) {
+  const strip = getActivityStrip(dir);
+  if (!strip) return;
+  strip.hidden = false;
+  const slot = ensureActiveSlot(strip);
+  slot.dataset.key = activeKey(relative_path, peer);
+  slot.innerHTML =
+    `<span class="sync-active">Syncing <code>${escapeHtml(relative_path)}</code> ` +
+    `from <strong>${escapeHtml(peerLabel(peer))}</strong>&hellip;</span>`;
+}
+
+export function setSyncCompleted({ dir, relative_path, peer }) {
+  const strip = getActivityStrip(dir);
+  if (!strip) return;
+  strip.hidden = false;
+  const slot = strip.querySelector(".dir-activity-current");
+  if (slot && slot.dataset.key === activeKey(relative_path, peer)) {
+    slot.remove();
+  }
+  pushHistory(
+    strip,
+    `<span class="sync-done">synced <code>${escapeHtml(relative_path)}</code></span>`,
+  );
+}
+
+export function setSyncFailed({ dir, relative_path, peer, reason }) {
+  const strip = getActivityStrip(dir);
+  if (!strip) return;
+  strip.hidden = false;
+  const slot = strip.querySelector(".dir-activity-current");
+  if (slot && slot.dataset.key === activeKey(relative_path, peer)) {
+    slot.remove();
+  }
+  pushHistory(
+    strip,
+    `<span class="sync-failed">failed <code>${escapeHtml(relative_path)}</code>` +
+      ` &mdash; ${escapeHtml(reason)}</span>`,
+  );
 }

--- a/gui/static/sse.js
+++ b/gui/static/sse.js
@@ -2,7 +2,10 @@ import {
   addPeerToList,
   setPeerAsDisconnected,
   addDirToList,
-  removeDirFromList
+  removeDirFromList,
+  setSyncStarted,
+  setSyncCompleted,
+  setSyncFailed
 } from './components.js';
 
 const el_peer_list = document.getElementById("peer-list");
@@ -39,6 +42,18 @@ es.onmessage = (event) => {
 
     case "SyncDirectoryRemoved":
       removeDirFromList(payload);
+      break;
+
+    case "EntrySyncStarted":
+      setSyncStarted(payload);
+      break;
+
+    case "EntrySyncCompleted":
+      setSyncCompleted(payload);
+      break;
+
+    case "EntrySyncFailed":
+      setSyncFailed(payload);
       break;
   }
 };

--- a/gui/static/style.css
+++ b/gui/static/style.css
@@ -155,6 +155,43 @@ main>section>header {
     }
 }
 
+.dir-activity {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin: 0.5rem 0;
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--border-radius);
+    background-color: var(--bg-color);
+    font-size: 0.85rem;
+}
+
+.dir-activity[hidden] {
+    display: none;
+}
+
+.dir-activity-current .sync-active {
+    color: var(--success-color);
+}
+
+.dir-activity-history {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.dir-activity-history .sync-done {
+    color: var(--success-color);
+    opacity: 0.85;
+}
+
+.dir-activity-history .sync-failed {
+    color: var(--disconnected-color);
+}
+
 #add-dir-dialog,
 #remove-dir-dialog,
 #home-path-dialog {


### PR DESCRIPTION
Closes #17

Adds three new `ServerEvent` variants (`EntrySyncStarted` / `EntrySyncCompleted` / `EntrySyncFailed`), broadcasts them from the transport receive path, and renders a per-directory activity strip in the GUI with a rolling history of the last five completed/failed entries.