### PR TITLE
feat: expose app version at startup, GUI, headers, and /api/info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,10 @@ Never construct a production `AppState` from a test (the binary builds it via `S
 
 `gui/index.html` is a single-page UI rendered via `minijinja` and served by axum; static assets in `gui/static/`. The server pushes live updates to the GUI over SSE using `ServerEvent` broadcast through `AppState::sse_sender()`. Variants currently include peer connect/disconnect, sync-directory add/remove, `ServerRestart`, and the per-entry `EntrySyncStarted` / `EntrySyncCompleted` / `EntrySyncFailed` events broadcast from the transport receiver path so the GUI can show live per-directory sync activity.
 
+### App version
+
+The crate version (`env!("CARGO_PKG_VERSION")`, from `app/Cargo.toml`) is the single source of truth and is surfaced at runtime in five places: the startup log line in `main.rs`, the `version` field on the root `synche` tracing span, the GUI footer (via the `version` template variable in `infra/http/gui.rs`), the `X-Synche-Version` response header inserted by the middleware in `infra/http/server.rs`, and the `GET /api/info` endpoint in `infra/http/api.rs`. Never introduce a second source — always read through `env!`.
+
 ### Logging
 
 Subscriber wired in `main.rs` via `utils::logging::init(dirs.log_dir())`. Returns a `LogGuards` that **must outlive `main`** — dropping it discards in-flight log lines from the non-blocking file appender.

--- a/app/src/application/sync.rs
+++ b/app/src/application/sync.rs
@@ -229,7 +229,11 @@ impl<W: FileWatcherInterface, T: TransportInterface, P: PersistenceInterface, D:
     #[tracing::instrument(
         name = "synche",
         skip_all,
-        fields(device = %self.state.local_id(), instance = %self.state.instance_id()),
+        fields(
+            device = %self.state.local_id(),
+            instance = %self.state.instance_id(),
+            version = env!("CARGO_PKG_VERSION"),
+        ),
     )]
     async fn _run(&mut self) -> io::Result<()> {
         tokio::select!(

--- a/app/src/infra/http/api.rs
+++ b/app/src/infra/http/api.rs
@@ -6,17 +6,18 @@ use crate::{
 };
 use async_stream::try_stream;
 use axum::{
-    Router,
+    Json, Router,
     extract::{Query, State},
     http::StatusCode,
     response::{Sse, sse::Event},
     routing::{get, post},
 };
 use futures_util::stream::Stream;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc};
 use tokio::sync::broadcast;
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 #[derive(Clone)]
 struct ApiState<P: PersistenceInterface> {
@@ -37,6 +38,14 @@ struct SetHomePathParams {
     pub path: String,
 }
 
+#[derive(Serialize)]
+struct InfoResponse {
+    pub version: &'static str,
+    pub device_id: Uuid,
+    pub instance_id: Uuid,
+    pub hostname: String,
+}
+
 /// JSON API routes — peer listing, sync-directory management,
 /// `home_path` updates, and the SSE stream of `ServerEvent`s.
 pub fn routes<P: PersistenceInterface>(
@@ -54,11 +63,23 @@ pub fn routes<P: PersistenceInterface>(
         "/api",
         Router::new()
             .route("/events", get(sse_events::<P>))
+            .route("/info", get(info::<P>))
             .route("/add-sync-dir", post(add_sync_dir::<P>))
             .route("/remove-sync-dir", post(remove_sync_dir::<P>))
             .route("/set-home-path", post(set_home_path::<P>))
             .with_state(api_state),
     )
+}
+
+async fn info<P: PersistenceInterface>(
+    State(state): State<Arc<ApiState<P>>>,
+) -> Json<InfoResponse> {
+    Json(InfoResponse {
+        version: env!("CARGO_PKG_VERSION"),
+        device_id: state.state.local_id(),
+        instance_id: state.state.instance_id(),
+        hostname: state.state.hostname().clone(),
+    })
 }
 
 async fn add_sync_dir<P: PersistenceInterface>(
@@ -394,6 +415,23 @@ mod tests {
             StatusCode::BAD_REQUEST,
             "File path should be rejected"
         );
+    }
+
+    #[tokio::test]
+    async fn test_info_returns_version_and_ids() {
+        let (_env, state, pm, em) = create_test_components().await;
+        let api_state = Arc::new(ApiState {
+            state: state.clone(),
+            peer_manager: pm,
+            entry_manager: em,
+        });
+
+        let Json(body) = info(State(api_state)).await;
+
+        assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(body.device_id, state.local_id());
+        assert_eq!(body.instance_id, state.instance_id());
+        assert_eq!(&body.hostname, state.hostname());
     }
 
     #[tokio::test]

--- a/app/src/infra/http/gui.rs
+++ b/app/src/infra/http/gui.rs
@@ -53,6 +53,7 @@ async fn index<P: PersistenceInterface>(
             peers => state.peer_manager.list().await,
             local_ip => state.state.local_ip().await,
             home_path => state.state.home_path().display().to_string(),
+            version => env!("CARGO_PKG_VERSION"),
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -150,6 +151,10 @@ mod tests {
         assert!(
             html.contains(&state.local_ip().await.to_string()),
             "Should contain local_ip"
+        );
+        assert!(
+            html.contains(env!("CARGO_PKG_VERSION")),
+            "Should contain crate version in footer"
         );
     }
 }

--- a/app/src/infra/http/server.rs
+++ b/app/src/infra/http/server.rs
@@ -4,10 +4,19 @@ use crate::{
     },
     infra::http::routes,
 };
+use axum::{
+    extract::Request,
+    http::{HeaderName, HeaderValue},
+    middleware::{self, Next},
+    response::Response,
+};
 use minijinja::Environment;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tower_http::trace::TraceLayer;
+
+const VERSION_HEADER: HeaderName = HeaderName::from_static("x-synche-version");
+const VERSION_HEADER_VALUE: HeaderValue = HeaderValue::from_static(env!("CARGO_PKG_VERSION"));
 
 /// Binds the HTTP listener on the configured port and serves the GUI
 /// and JSON API. Runs until the listener errors or the task is
@@ -21,12 +30,24 @@ pub async fn run<P: PersistenceInterface>(
     let template_engine = init_template_engine();
 
     let router = routes::build_router(state, peer_manager, entry_manager, template_engine)
+        .layer(middleware::from_fn(insert_version_header))
         .layer(TraceLayer::new_for_http());
 
     let addr = format!("0.0.0.0:{port}");
     let listener = TcpListener::bind(&addr).await?;
     tracing::info!("Web GUI: http://{addr}");
     axum::serve(listener, router).await
+}
+
+/// Inserts `X-Synche-Version: <CARGO_PKG_VERSION>` on every outgoing
+/// response so scripted health checks and curl can read the version
+/// without parsing a JSON body.
+async fn insert_version_header(request: Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    response
+        .headers_mut()
+        .insert(VERSION_HEADER, VERSION_HEADER_VALUE);
+    response
 }
 
 /// Builds the minijinja environment with the GUI template embedded at

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -9,5 +9,7 @@ async fn main() -> tokio::io::Result<()> {
     // Must outlive `main`: dropping the guard discards in-flight log lines.
     let _log_guards = utils::logging::init(dirs.log_dir().as_ref());
 
+    tracing::info!("Synche v{}", env!("CARGO_PKG_VERSION"));
+
     application::Synchronizer::run_default_with_restart(dirs).await
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,6 +4,8 @@ Synche exposes a small HTTP API for managing sync directories and streaming real
 
 All requests use query parameters — there are no JSON request bodies.  Responses carry only an HTTP status code; error details are emitted to the server log.
 
+Every response from the server (GUI, API, SSE, static assets) carries an `X-Synche-Version` header set to the running crate version (e.g. `X-Synche-Version: 0.0.4-alpha`).  This lets scripted health checks read the version without parsing a JSON body.
+
 > **Source:** [`app/src/infra/http/api.rs`](../app/src/infra/http/api.rs) · [`app/src/domain/sse.rs`](../app/src/domain/sse.rs)
 
 ---
@@ -27,6 +29,37 @@ Streams [`ServerEvent`](#server-sent-events) objects to the client as newline-de
 - The broadcast channel has a capacity of **100 events**.  If a client falls behind, it is warned in the log and continues receiving subsequent messages (intermediate events are skipped).
 - When the broadcast channel closes (e.g. after a clean shutdown), the stream ends.
 - A `ServerRestart` event is sent before any in-process restart so the client knows to reconnect.
+
+---
+
+### `GET /api/info` — Runtime identity
+
+Returns a small JSON document describing the running instance.  Useful for monitoring scripts, CLI tooling, and version-aware clients.
+
+| | |
+|---|---|
+| **Method** | `GET` |
+| **Query params** | none |
+| **Content-Type** | `application/json` |
+| **Status** | `200 OK` |
+
+**Response body:**
+
+```json
+{
+  "version": "0.0.4-alpha",
+  "device_id": "550e8400-e29b-41d4-a716-446655440000",
+  "instance_id": "7b3f9c1a-2d4e-4f5a-b6c7-d8e9f0a1b2c3",
+  "hostname": "mymachine"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | string | Crate version compiled into the binary (`CARGO_PKG_VERSION`) |
+| `device_id` | UUID string | Persistent device identifier (`local_id`) |
+| `instance_id` | UUID string | Regenerated on every process start |
+| `hostname` | string | Local machine hostname (`.local` suffix stripped) |
 
 ---
 
@@ -117,6 +150,7 @@ Renders the Synche single-page UI as an HTML page.  The template receives the cu
 | `peers` | list of peer objects | Currently connected peers |
 | `local_ip` | IP address string | Local network IP address |
 | `home_path` | string | Absolute path of the current home directory |
+| `version` | string | Crate version compiled into the binary (`CARGO_PKG_VERSION`) |
 
 | Status | Meaning |
 |--------|---------|
@@ -292,6 +326,7 @@ name = "Documents"
 | Route | Method | Query params | Status codes |
 |-------|--------|--------------|-------------|
 | `/api/events` | GET | — | 200 (SSE stream) |
+| `/api/info` | GET | — | 200 |
 | `/api/add-sync-dir` | POST | `name` | 201, 409, 500 |
 | `/api/remove-sync-dir` | POST | `name` | 200, 500 |
 | `/api/set-home-path` | POST | `path` | 200, 400, 500 |

--- a/gui/index.html
+++ b/gui/index.html
@@ -402,7 +402,7 @@
         </main>
 
         <footer>
-            <span>© 2025 Synche</span>
+            <span>© 2025 Synche &bull; v{{ version }}</span>
             <a href="https://github.com/matx64/synche/"
                 ><svg
                     xmlns="http://www.w3.org/2000/svg"

--- a/gui/index.html
+++ b/gui/index.html
@@ -402,7 +402,7 @@
         </main>
 
         <footer>
-            <span>© 2025 Synche &bull; v{{ version }}</span>
+            <span>© 2026 Synche &bull; v{{ version }}</span>
             <a href="https://github.com/matx64/synche/"
                 ><svg
                     xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Closes #31

Surfaces the crate version (`env!("CARGO_PKG_VERSION")`) at runtime in five places:

- Startup log line in `main.rs`.
- `version` field on the root `synche` tracing span.
- GUI footer (`v{{ version }}`).
- `X-Synche-Version` response header on every HTTP response.
- New `GET /api/info` endpoint returning `version`, `device_id`, `instance_id`, `hostname`.

`AGENTS.md` and `docs/API.md` updated accordingly.