### PR TITLE
feat: scope inbound peer data to sync dirs and harden version-vector merging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Every inbound `Metadata`/`Request`/`Transfer` handler in `TransportReceiver` (`a
 
 ### Sanitizing peer-supplied version vectors
 
-Any path that persists a peer-supplied `EntryInfo` must strip foreign axes and reject counters above `MAX_TRUSTED_COUNTER` first. The hardened paths are `EntryManager::merge_versions_and_insert` (on the `Equal | KeepSelf` branch of `compare_and_resolve_conflict`) and `EntryManager::insert_peer_entry` (used by `TransportReceiver::handle_transfer` and `create_received_dir` on first-sight Transfer / directory-create). `TcpReceiver` must reject or drain-and-drop poisoned `Transfer` frames before disk writes, since the file bytes are materialized before metadata is persisted. Plain `insert_entry` is for trusted local writes only — never call it directly on a peer-supplied entry.
+Any path that persists a peer-supplied `EntryInfo` must strip foreign axes and reject counters above `MAX_TRUSTED_COUNTER` first. The hardened paths are `EntryManager::merge_versions_and_insert` (on the `Equal | KeepSelf` branch of `compare_and_resolve_conflict`) and `EntryManager::insert_peer_entry` (used by `TransportReceiver::handle_transfer` and `create_received_dir` for accepted Transfer / directory-create entries). When replacing an existing row with a peer entry, preserve the trusted existing version vector and merge only the sender's own inbound axis; never reset the local axis to zero after accepting a transfer. `TcpReceiver` must reject or drain-and-drop poisoned `Transfer` frames before disk writes, since the file bytes are materialized before metadata is persisted. Plain `insert_entry` is for trusted local writes only — never call it directly on a peer-supplied entry.
 
 ### Peer identity is currently untrusted
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Remote transport paths must be validated before any metadata handling or disk wr
 
 ### Scoping inbound entries to configured sync_dirs
 
-Every inbound `Metadata`/`Request`/`Transfer` handler in `TransportReceiver` (`app/src/application/network/transport/receiver.rs`) drops entries whose top component is not a configured sync directory. The guard is `TransportReceiver::is_in_configured_sync_dir`, which delegates to `AppState::contains_sync_dir`. The same check already runs in `EntryManager::get_entries_to_request` and `build_db`. If you add a new inbound entry path, add the guard alongside the existing `is_git_path` filter — they belong together.
+Every inbound `Metadata`/`Request`/`Transfer` handler in `TransportReceiver` (`app/src/application/network/transport/receiver.rs`) drops entries whose top component is not a configured sync directory. The guard is `TransportReceiver::is_in_configured_sync_dir`, which delegates to `AppState::contains_sync_dir`. The same check already runs in `EntryManager::get_entries_to_request` and `build_db`. `TcpReceiver` must also enforce the configured-sync-dir guard before staging or finalizing inbound `Transfer` bytes, because application-layer filtering happens after the TCP adapter has decoded the frame. If you add a new inbound entry path, add the guard alongside the existing `is_git_path` filter — they belong together.
 
 "Path under sync dir" checks must be component-aware: use `RelativePath::starts_with_dir`, never `str::starts_with` on a `RelativePath`. The dereference-to-`str` makes it look right, but `foo` would then match `foobar/...`.
 
@@ -84,7 +84,7 @@ Every inbound `Metadata`/`Request`/`Transfer` handler in `TransportReceiver` (`a
 
 ### Sanitizing peer-supplied version vectors
 
-Any path that persists a peer-supplied `EntryInfo` must strip foreign axes and reject counters above `MAX_TRUSTED_COUNTER` first. The hardened paths are `EntryManager::merge_versions_and_insert` (on the `Equal | KeepSelf` branch of `compare_and_resolve_conflict`) and `EntryManager::insert_peer_entry` (used by `TransportReceiver::handle_transfer` and `create_received_dir` on first-sight Transfer / directory-create). Plain `insert_entry` is for trusted local writes only — never call it directly on a peer-supplied entry.
+Any path that persists a peer-supplied `EntryInfo` must strip foreign axes and reject counters above `MAX_TRUSTED_COUNTER` first. The hardened paths are `EntryManager::merge_versions_and_insert` (on the `Equal | KeepSelf` branch of `compare_and_resolve_conflict`) and `EntryManager::insert_peer_entry` (used by `TransportReceiver::handle_transfer` and `create_received_dir` on first-sight Transfer / directory-create). `TcpReceiver` must reject or drain-and-drop poisoned `Transfer` frames before disk writes, since the file bytes are materialized before metadata is persisted. Plain `insert_entry` is for trusted local writes only — never call it directly on a peer-supplied entry.
 
 ### Peer identity is currently untrusted
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,20 @@ Permanent path exclusions must be enforced at every boundary where entries can e
 
 Remote transport paths must be validated before any metadata handling or disk write. Use `RelativePath::is_safe_sync_path` to reject absolute paths, parent-directory traversal, empty paths, and backslash-separated paths from peers.
 
+### Scoping inbound entries to configured sync_dirs
+
+Every inbound `Metadata`/`Request`/`Transfer` handler in `TransportReceiver` (`app/src/application/network/transport/receiver.rs`) drops entries whose top component is not a configured sync directory. The guard is `TransportReceiver::is_in_configured_sync_dir`, which delegates to `AppState::contains_sync_dir`. The same check already runs in `EntryManager::get_entries_to_request` and `build_db`. If you add a new inbound entry path, add the guard alongside the existing `is_git_path` filter — they belong together.
+
+"Path under sync dir" checks must be component-aware: use `RelativePath::starts_with_dir`, never `str::starts_with` on a `RelativePath`. The dereference-to-`str` makes it look right, but `foo` would then match `foobar/...`.
+
+### Inbound TCP message size caps
+
+`app/src/infra/network/tcp/chunk.rs` defines three hard caps that are enforced **before** allocating: `MAX_TRANSFER_SIZE` (raw file bytes), `MAX_HANDSHAKE_JSON_SIZE` (handshake JSON), `MAX_ENTRY_JSON_SIZE` (single `EntryInfo` JSON). Anything that decodes a peer-supplied `u32` length must check it against the right cap before `vec![0u8; len]`. Don't add a new variable-length frame without picking (or adding) a cap.
+
+### Peer identity is currently untrusted
+
+`source_id` on the TCP frame is read off the wire and **not** verified — there is no TLS or signature today. The follow-up tracked under issue #32 will replace this with mutual TLS or Noise IK. Until that lands, any code that decides "is this peer allowed to do X" cannot trust `source_id` for cross-peer authorization — only use it for routing.
+
 ### Runtime / data files (not in repo)
 
 State lives in the OS config dir (`dirs::config_dir()` + `synche/`), not the repo. The paths are resolved through a `SyncheDirs` value type (`app/src/utils/dirs.rs`) carried on `AppState`, **not** through global statics — tests rely on injecting per-test `SyncheDirs` for isolation. Production code goes through `AppState::new_from_os()` and reads paths via `state.dirs()`. Don't reintroduce global `OnceLock`s for these directories.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,10 @@ Every inbound `Metadata`/`Request`/`Transfer` handler in `TransportReceiver` (`a
 
 `app/src/infra/network/tcp/chunk.rs` defines three hard caps that are enforced **before** allocating: `MAX_TRANSFER_SIZE` (raw file bytes), `MAX_HANDSHAKE_JSON_SIZE` (handshake JSON), `MAX_ENTRY_JSON_SIZE` (single `EntryInfo` JSON). Anything that decodes a peer-supplied `u32` length must check it against the right cap before `vec![0u8; len]`. Don't add a new variable-length frame without picking (or adding) a cap.
 
+### Sanitizing peer-supplied version vectors
+
+Any path that persists a peer-supplied `EntryInfo` must strip foreign axes and reject counters above `MAX_TRUSTED_COUNTER` first. The hardened paths are `EntryManager::merge_versions_and_insert` (on the `Equal | KeepSelf` branch of `compare_and_resolve_conflict`) and `EntryManager::insert_peer_entry` (used by `TransportReceiver::handle_transfer` and `create_received_dir` on first-sight Transfer / directory-create). Plain `insert_entry` is for trusted local writes only — never call it directly on a peer-supplied entry.
+
 ### Peer identity is currently untrusted
 
 `source_id` on the TCP frame is read off the wire and **not** verified — there is no TLS or signature today. The follow-up tracked under issue #32 will replace this with mutual TLS or Noise IK. Until that lands, any code that decides "is this peer allowed to do X" cannot trust `source_id` for cross-peer authorization — only use it for routing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ Every inbound `Metadata`/`Request`/`Transfer` handler in `TransportReceiver` (`a
 
 Any path that persists a peer-supplied `EntryInfo` must strip foreign axes and reject counters above `MAX_TRUSTED_COUNTER` first. The hardened paths are `EntryManager::merge_versions_and_insert` (on the `Equal | KeepSelf` branch of `compare_and_resolve_conflict`) and `EntryManager::insert_peer_entry` (used by `TransportReceiver::handle_transfer` and `create_received_dir` for accepted Transfer / directory-create entries). When replacing an existing row with a peer entry, preserve the trusted existing version vector and merge only the sender's own inbound axis; never reset the local axis to zero after accepting a transfer. `TcpReceiver` must reject or drain-and-drop poisoned `Transfer` frames before disk writes, since the file bytes are materialized before metadata is persisted. Plain `insert_entry` is for trusted local writes only — never call it directly on a peer-supplied entry.
 
+Comparison decisions must use the same sanitized peer view before calling `EntryInfo::compare`. Do not let foreign axes influence `handle_metadata`, handshake request selection, conflict resolution, delete decisions, or transfer requests; sanitize to the sender's own axis first, then persist through the hardened paths above.
+
 ### Peer identity is currently untrusted
 
 `source_id` on the TCP frame is read off the wire and **not** verified — there is no TLS or signature today. The follow-up tracked under issue #32 will replace this with mutual TLS or Noise IK. Until that lands, any code that decides "is this peer allowed to do X" cannot trust `source_id` for cross-peer authorization — only use it for routing.

--- a/app/src/application/network/transport/receiver.rs
+++ b/app/src/application/network/transport/receiver.rs
@@ -172,7 +172,7 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
             _ => unreachable!(),
         };
 
-        if is_git_path(&peer_entry.name) {
+        if is_git_path(&peer_entry.name) || !self.is_in_configured_sync_dir(&peer_entry).await {
             return Ok(());
         }
 
@@ -209,7 +209,9 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
             _ => unreachable!(),
         };
 
-        if is_git_path(&requested_entry.name) {
+        if is_git_path(&requested_entry.name)
+            || !self.is_in_configured_sync_dir(&requested_entry).await
+        {
             return Ok(());
         }
 
@@ -238,7 +240,9 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
             _ => unreachable!(),
         };
 
-        if is_git_path(&received_entry.name) {
+        if is_git_path(&received_entry.name)
+            || !self.is_in_configured_sync_dir(&received_entry).await
+        {
             return Ok(());
         }
 
@@ -250,6 +254,14 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
             .send(TransportChannelData::Metadata(entry))
             .await
             .map_err(io::Error::other)
+    }
+
+    /// Returns true if `entry`'s top-level component is one of the
+    /// directories the local user has opted in to syncing. Acts as a
+    /// scope guard for inbound Metadata / Request / Transfer so a peer
+    /// cannot push or pull data outside the configured sync set.
+    async fn is_in_configured_sync_dir(&self, entry: &EntryInfo) -> bool {
+        self.state.contains_sync_dir(&entry.get_sync_dir()).await
     }
 
     fn broadcast_sync_started(&self, peer: Uuid, entry: &EntryInfo) {
@@ -340,7 +352,10 @@ mod tests {
         Arc<EntryManager<SqliteDb>>,
         tokio::sync::mpsc::Receiver<TransportChannelData>,
     ) {
-        let env = crate::utils::test_support::test_env().await;
+        // Use "sync" as the configured directory so the existing
+        // `sync/...` entry paths are inside a configured sync dir
+        // (scope guard added for issue #32).
+        let env = crate::utils::test_support::test_env_with_dirs(&["sync"]).await;
         let state = env.state.clone();
         let db = SqliteDb::new(":memory:").await.unwrap();
         let entry_manager = EntryManager::new(db, state.clone());
@@ -447,6 +462,65 @@ mod tests {
             }
             other => panic!("unexpected event: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn handle_metadata_drops_entries_outside_configured_sync_dirs() {
+        let (_env, receiver, entry_manager, mut send_rx) = setup().await;
+        // "other" is not in the configured sync_dirs (only "sync" is).
+        let entry = file_entry("other/payload.bin");
+
+        receiver
+            .handle_metadata(event(TransportData::Metadata(entry.clone())))
+            .await
+            .unwrap();
+
+        assert!(
+            entry_manager
+                .get_entry(&entry.name)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(matches!(send_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn handle_request_drops_entries_outside_configured_sync_dirs() {
+        let (_env, receiver, entry_manager, mut send_rx) = setup().await;
+        let entry = file_entry("other/payload.bin");
+        // Force-insert the entry to prove the scope guard rejects the
+        // request before any DB lookup or transfer enqueue.
+        entry_manager.insert_entry(entry.clone()).await.unwrap();
+
+        receiver
+            .handle_request(event(TransportData::Request(entry)))
+            .await
+            .unwrap();
+
+        assert!(matches!(send_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn handle_transfer_drops_entries_outside_configured_sync_dirs() {
+        let (env, receiver, entry_manager, mut send_rx) = setup().await;
+        let mut sse_rx = env.state.sse_subscribe();
+        let entry = file_entry("other/payload.bin");
+
+        receiver
+            .handle_transfer(event(TransportData::Transfer(entry.clone())))
+            .await
+            .unwrap();
+
+        assert!(
+            entry_manager
+                .get_entry(&entry.name)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(matches!(send_rx.try_recv(), Err(TryRecvError::Empty)));
+        assert!(sse_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/app/src/application/network/transport/receiver.rs
+++ b/app/src/application/network/transport/receiver.rs
@@ -159,7 +159,8 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
                     .await
                     .map_err(io::Error::other)?;
             } else {
-                self.create_received_dir(entry).await?;
+                self.create_received_dir(event.metadata.source_id, entry)
+                    .await?;
             }
         }
         Ok(())
@@ -194,7 +195,8 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
                         .await
                         .map_err(io::Error::other)
                 } else {
-                    self.create_received_dir(peer_entry).await
+                    self.create_received_dir(event.metadata.source_id, peer_entry)
+                        .await
                 }
             }
 
@@ -246,7 +248,13 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
             return Ok(());
         }
 
-        let entry = self.entry_manager.insert_entry(received_entry).await?;
+        let Some(entry) = self
+            .entry_manager
+            .insert_peer_entry(event.metadata.source_id, received_entry)
+            .await?
+        else {
+            return Ok(());
+        };
 
         self.broadcast_sync_completed(event.metadata.source_id, &entry);
 
@@ -283,8 +291,10 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
             });
     }
 
-    async fn create_received_dir(&self, dir: EntryInfo) -> io::Result<()> {
-        let dir = self.entry_manager.insert_entry(dir).await?;
+    async fn create_received_dir(&self, peer_id: Uuid, dir: EntryInfo) -> io::Result<()> {
+        let Some(dir) = self.entry_manager.insert_peer_entry(peer_id, dir).await? else {
+            return Ok(());
+        };
 
         let path = dir.name.to_canonical(self.state.home_path());
         fs::create_dir_all(path).await?;
@@ -498,6 +508,68 @@ mod tests {
             .await
             .unwrap();
 
+        assert!(matches!(send_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn handle_transfer_strips_foreign_axes_from_peer_version_vector() {
+        let (_env, receiver, entry_manager, _send_rx) = setup().await;
+        let peer = Uuid::new_v4();
+        let third = Uuid::new_v4();
+        let entry = EntryInfo {
+            name: "sync/payload.bin".into(),
+            kind: EntryKind::File,
+            hash: Some("hash".into()),
+            // Peer reports its own axis AND a claim about `third`'s
+            // counter — only the peer's own axis must be persisted.
+            version: HashMap::from([(peer, 3), (third, 99)]),
+        };
+
+        let evt = TransportEvent {
+            payload: TransportData::Transfer(entry.clone()),
+            metadata: TransportMetadata {
+                source_id: peer,
+                source_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            },
+        };
+        receiver.handle_transfer(evt).await.unwrap();
+
+        let stored = entry_manager.get_entry(&entry.name).await.unwrap().unwrap();
+        assert_eq!(stored.version.get(&peer), Some(&3));
+        assert!(
+            !stored.version.contains_key(&third),
+            "foreign axis must not be persisted from Transfer"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_transfer_drops_entry_with_poisoned_peer_counter() {
+        let (_env, receiver, entry_manager, mut send_rx) = setup().await;
+        let peer = Uuid::new_v4();
+        let entry = EntryInfo {
+            name: "sync/payload.bin".into(),
+            kind: EntryKind::File,
+            hash: Some("hash".into()),
+            version: HashMap::from([(peer, u64::MAX)]),
+        };
+
+        let evt = TransportEvent {
+            payload: TransportData::Transfer(entry.clone()),
+            metadata: TransportMetadata {
+                source_id: peer,
+                source_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            },
+        };
+        receiver.handle_transfer(evt).await.unwrap();
+
+        assert!(
+            entry_manager
+                .get_entry(&entry.name)
+                .await
+                .unwrap()
+                .is_none(),
+            "poisoned peer entry must not be persisted"
+        );
         assert!(matches!(send_rx.try_recv(), Err(TryRecvError::Empty)));
     }
 

--- a/app/src/application/state/app_state.rs
+++ b/app/src/application/state/app_state.rs
@@ -246,9 +246,13 @@ impl AppState {
     /// Returns `true` if `path` falls under any configured sync
     /// directory — the boundary check that decides whether a watcher
     /// event is relevant.
+    ///
+    /// Uses component-aware matching via `RelativePath::starts_with_dir`,
+    /// so a configured dir `foo` does **not** match a sibling path
+    /// `foobar/file.txt`.
     pub async fn is_under_sync_dir(&self, path: &RelativePath) -> bool {
         let dirs = self.sync_dirs.read().await;
-        dirs.keys().any(|d| path.starts_with(&**d))
+        dirs.keys().any(|d| path.starts_with_dir(d))
     }
 }
 
@@ -443,6 +447,23 @@ mod tests {
                 "Sync dir itself should match is_under_sync_dir"
             );
         }
+    }
+
+    /// Verifies the component-aware boundary check (issue #32 finding
+    /// #4). A configured sync dir `foo` must NOT match a sibling path
+    /// like `foobar/file.txt`.
+    #[tokio::test]
+    async fn is_under_sync_dir_does_not_match_string_prefix_siblings() {
+        let env = crate::utils::test_support::test_env_with_dirs(&["foo"]).await;
+
+        assert!(
+            env.state.is_under_sync_dir(&"foo/file.txt".into()).await,
+            "child path under foo/ should match"
+        );
+        assert!(
+            !env.state.is_under_sync_dir(&"foobar/file.txt".into()).await,
+            "string-prefix sibling foobar/ must NOT match foo"
+        );
     }
 
     #[tokio::test]

--- a/app/src/application/state/entry_manager.rs
+++ b/app/src/application/state/entry_manager.rs
@@ -228,18 +228,15 @@ impl<P: PersistenceInterface> EntryManager<P> {
     /// Drops all foreign axes (only `entry.version[peer_id]` is trusted)
     /// and rejects counters above `MAX_TRUSTED_COUNTER` as poisoned. The
     /// same rule that `merge_versions_and_insert` applies on the
-    /// `Equal | KeepSelf` branch, applied at the first-sight Transfer /
+    /// `Equal | KeepSelf` branch, applied at the Transfer /
     /// directory-create boundary so a peer cannot poison foreign axes
-    /// or write `u64::MAX` counters into the DB on initial sync.
+    /// or write `u64::MAX` counters into the DB.
     ///
-    /// Contract: **first-sight callers only.** The persisted vector is
-    /// rebuilt as `{peer_id: pv, local_id: 0}`, which unconditionally
-    /// resets the local axis. Safe for `handle_transfer` /
-    /// `create_received_dir` (the row is new, or its existing local
-    /// counter has already been incorporated into the version
-    /// comparison that decided to accept the peer's copy). Do **not**
-    /// call this on a path where a non-zero local axis still needs to
-    /// be preserved — go through `merge_versions_and_insert` instead.
+    /// If a row already exists, its trusted local vector is preserved
+    /// and only the sender's own axis is merged from the inbound entry.
+    /// This keeps the accepted peer copy from erasing local history,
+    /// which would make later local edits look stale against an older
+    /// peer advertisement.
     ///
     /// Returns `Ok(None)` if the entry was dropped (warn-and-drop),
     /// `Ok(Some(entry))` after a successful persist.
@@ -258,8 +255,15 @@ impl<P: PersistenceInterface> EntryManager<P> {
             );
             return Ok(None);
         }
-        entry.version = HashMap::from([(peer_id, pv)]);
-        entry.version.entry(self.state.local_id()).or_insert(0);
+        let mut version = self
+            .get_entry(&entry.name)
+            .await?
+            .map(|stored| stored.version)
+            .unwrap_or_default();
+        let peer_version = version.entry(peer_id).or_insert(0);
+        *peer_version = (*peer_version).max(pv);
+        version.entry(self.state.local_id()).or_insert(0);
+        entry.version = version;
         trace!(entry = %entry.name, peer = %peer_id, "inserting peer entry");
         self.db.insert_or_replace_entry(&entry).await?;
         Ok(Some(entry))
@@ -981,6 +985,65 @@ mod tests {
         assert!(
             observed < crate::domain::MAX_TRUSTED_COUNTER,
             "poisoned counter must not be persisted; got {observed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_peer_entry_preserves_existing_local_axis() {
+        let (_env, _temp_dir, sync_dir, manager) = setup().await;
+        let sync_root = add_sync_dir(&manager, &sync_dir).await;
+        let local_id = manager.state.local_id();
+        let peer_id = Uuid::new_v4();
+        let third_id = Uuid::new_v4();
+        let name = dir_relative(&sync_root, "shared.txt");
+
+        manager
+            .insert_entry(EntryInfo {
+                name: name.clone(),
+                kind: EntryKind::File,
+                hash: Some("local-old".into()),
+                version: HashMap::from([(local_id, 5), (peer_id, 2)]),
+            })
+            .await
+            .unwrap();
+
+        let accepted_peer_entry = EntryInfo {
+            name: name.clone(),
+            kind: EntryKind::File,
+            hash: Some("peer-copy".into()),
+            version: HashMap::from([(peer_id, 3), (third_id, 99)]),
+        };
+
+        let stored = manager
+            .insert_peer_entry(peer_id, accepted_peer_entry)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(stored.version.get(&local_id), Some(&5));
+        assert_eq!(stored.version.get(&peer_id), Some(&3));
+        assert!(
+            !stored.version.contains_key(&third_id),
+            "foreign axis must not be persisted from peer entry"
+        );
+
+        let locally_modified = manager
+            .entry_modified(stored, Some("local-new".into()))
+            .await
+            .unwrap();
+        let stale_peer_entry = EntryInfo {
+            name,
+            kind: EntryKind::File,
+            hash: Some("peer-copy".into()),
+            version: HashMap::from([(peer_id, 3)]),
+        };
+
+        assert!(
+            matches!(
+                locally_modified.compare(&stale_peer_entry),
+                VersionCmp::KeepSelf
+            ),
+            "local edit after accepting a transfer must not look stale"
         );
     }
 

--- a/app/src/application/state/entry_manager.rs
+++ b/app/src/application/state/entry_manager.rs
@@ -2,8 +2,8 @@ use super::{app_state::AppState, ignore::IgnoreHandler};
 use crate::{
     application::persistence::interface::PersistenceInterface,
     domain::{
-        CanonicalPath, EntryInfo, EntryKind, HandshakeData, Peer, RelativePath, SyncDirectory,
-        VersionCmp,
+        CanonicalPath, EntryInfo, EntryKind, HandshakeData, MAX_TRUSTED_COUNTER, Peer,
+        RelativePath, SyncDirectory, VersionCmp,
     },
     utils::fs::{compute_hash, is_ds_store, is_git_path},
 };
@@ -153,7 +153,7 @@ impl<P: PersistenceInterface> EntryManager<P> {
 
             match filesystem_entries.get(name) {
                 Some(fs_entry) if fs_entry.hash != entry.hash => {
-                    *entry.version.entry(self.state.local_id()).or_insert(0) += 1;
+                    bump_local_counter(&mut entry.version, self.state.local_id())?;
 
                     self.db
                         .insert_or_replace_entry(&EntryInfo {
@@ -244,7 +244,7 @@ impl<P: PersistenceInterface> EntryManager<P> {
         hash: Option<String>,
     ) -> io::Result<EntryInfo> {
         entry.hash = hash;
-        *entry.version.entry(self.state.local_id()).or_insert(0) += 1;
+        bump_local_counter(&mut entry.version, self.state.local_id())?;
 
         self.db.insert_or_replace_entry(&entry).await?;
         Ok(entry)
@@ -404,6 +404,15 @@ impl<P: PersistenceInterface> EntryManager<P> {
         }
     }
 
+    /// Merges the peer's version counter for **its own axis** into
+    /// the local copy and persists.
+    ///
+    /// Only `peer_entry.version[peer_id]` is trusted — foreign axes in
+    /// the inbound vector are ignored to prevent a buggy or hostile
+    /// peer from inflating another device's counter. A counter above
+    /// `MAX_TRUSTED_COUNTER` is treated as poisoned and the merge is
+    /// skipped (warn-and-drop) instead of erroring, so one bad entry
+    /// cannot tear down the connection.
     pub async fn merge_versions_and_insert(
         &self,
         local_entry: &mut EntryInfo,
@@ -412,9 +421,18 @@ impl<P: PersistenceInterface> EntryManager<P> {
     ) -> io::Result<()> {
         local_entry.version.entry(peer_id).or_insert(0);
 
-        for (pid, pv) in &peer_entry.version {
-            let local_version = local_entry.version.entry(*pid).or_insert(0);
-            *local_version = (*local_version).max(*pv);
+        if let Some(&pv) = peer_entry.version.get(&peer_id) {
+            if pv > MAX_TRUSTED_COUNTER {
+                warn!(
+                    entry = %local_entry.name,
+                    peer = %peer_id,
+                    counter = pv,
+                    "rejecting poisoned peer version counter"
+                );
+                return Ok(());
+            }
+            let local_version = local_entry.version.entry(peer_id).or_insert(0);
+            *local_version = (*local_version).max(pv);
         }
 
         trace!(entry = %local_entry.name, peer = %peer_id, "merging versions");
@@ -449,7 +467,7 @@ impl<P: PersistenceInterface> EntryManager<P> {
     pub async fn delete_and_update_entry(&self, mut entry: EntryInfo) -> io::Result<EntryInfo> {
         self.db.delete_entry(&entry.name).await?;
 
-        *entry.version.entry(self.state.local_id()).or_insert(0) += 1;
+        bump_local_counter(&mut entry.version, self.state.local_id())?;
         entry.set_removed_hash();
 
         Ok(entry)
@@ -489,6 +507,22 @@ impl<P: PersistenceInterface> EntryManager<P> {
     pub async fn remove_gitignore(&self, relative: &RelativePath) {
         self.ignore_handler.remove_gitignore(relative).await;
     }
+}
+
+/// Increment the local axis of a version vector with overflow checking.
+///
+/// With foreign-axis poisoning prevented in `merge_versions_and_insert`,
+/// this counter only grows via honest local edits, so overflow is
+/// unreachable in practice. `checked_add` is a cheap defense-in-depth.
+fn bump_local_counter(
+    version: &mut crate::domain::VersionVector,
+    local_id: Uuid,
+) -> io::Result<()> {
+    let v = version.entry(local_id).or_insert(0);
+    *v = v
+        .checked_add(1)
+        .ok_or_else(|| io::Error::other("version counter overflow"))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -821,10 +855,13 @@ mod tests {
         assert!(matches!(cmp, VersionCmp::KeepSelf));
     }
 
-    /// After a non-conflict handle_metadata, the local entry's version
-    /// vector must include every peer counter, taking the max.
+    /// After a non-conflict handle_metadata, only the peer's own axis
+    /// (`peer_entry.version[peer_id]`) is merged into the local vector.
+    /// Foreign axes the peer claims to know about are ignored, because
+    /// an unauthenticated peer can advertise arbitrary values for them
+    /// (issue #32 finding #3).
     #[tokio::test]
-    async fn handle_metadata_merges_peer_version_vector_into_local() {
+    async fn handle_metadata_merges_only_peer_own_axis() {
         let (_env, _temp_dir, sync_dir, manager) = setup().await;
         let sync_root = add_sync_dir(&manager, &sync_dir).await;
         let local_id = manager.state.local_id();
@@ -855,7 +892,54 @@ mod tests {
         let stored = manager.get_entry(&name).await.unwrap().unwrap();
         assert_eq!(stored.version.get(&local_id), Some(&2));
         assert_eq!(stored.version.get(&peer_id), Some(&4));
-        assert_eq!(stored.version.get(&third_id), Some(&7));
+        // Third-device axis must NOT have been adopted from the peer's
+        // claim — we'd only learn it by hearing from `third_id` directly.
+        assert!(
+            !stored.version.contains_key(&third_id),
+            "foreign axis must not be merged from peer report"
+        );
+    }
+
+    /// A peer-supplied counter above `MAX_TRUSTED_COUNTER` is treated as
+    /// poisoned: the merge is skipped (warn-and-drop) so future
+    /// legitimate updates from that device don't look stale forever
+    /// (issue #32 finding #5).
+    #[tokio::test]
+    async fn merge_versions_skips_poisoned_peer_counter() {
+        let (_env, _temp_dir, sync_dir, manager) = setup().await;
+        let sync_root = add_sync_dir(&manager, &sync_dir).await;
+        let local_id = manager.state.local_id();
+        let peer_id = Uuid::new_v4();
+        let name = dir_relative(&sync_root, "shared.txt");
+
+        manager
+            .insert_entry(EntryInfo {
+                name: name.clone(),
+                kind: EntryKind::File,
+                hash: Some("same-hash".into()),
+                version: HashMap::from([(local_id, 2)]),
+            })
+            .await
+            .unwrap();
+
+        let peer_entry = EntryInfo {
+            name: name.clone(),
+            kind: EntryKind::File,
+            hash: Some("same-hash".into()),
+            version: HashMap::from([(peer_id, u64::MAX)]),
+        };
+
+        // Equal kind + hash + dominated local axis means handle_metadata
+        // would normally try to merge — the poisoned counter must abort
+        // that merge cleanly rather than persist `u64::MAX`.
+        manager.handle_metadata(peer_id, &peer_entry).await.unwrap();
+
+        let stored = manager.get_entry(&name).await.unwrap().unwrap();
+        let observed = stored.version.get(&peer_id).copied().unwrap_or(0);
+        assert!(
+            observed < crate::domain::MAX_TRUSTED_COUNTER,
+            "poisoned counter must not be persisted; got {observed}"
+        );
     }
 
     #[tokio::test]

--- a/app/src/application/state/entry_manager.rs
+++ b/app/src/application/state/entry_manager.rs
@@ -223,6 +223,39 @@ impl<P: PersistenceInterface> EntryManager<P> {
         Ok(entry)
     }
 
+    /// Persist a peer-supplied entry after sanitizing its version vector.
+    ///
+    /// Drops all foreign axes (only `entry.version[peer_id]` is trusted)
+    /// and rejects counters above `MAX_TRUSTED_COUNTER` as poisoned. The
+    /// same rule that `merge_versions_and_insert` applies on the
+    /// `Equal | KeepSelf` branch, applied at the first-sight Transfer /
+    /// directory-create boundary so a peer cannot poison foreign axes
+    /// or write `u64::MAX` counters into the DB on initial sync.
+    ///
+    /// Returns `Ok(None)` if the entry was dropped (warn-and-drop),
+    /// `Ok(Some(entry))` after a successful persist.
+    pub async fn insert_peer_entry(
+        &self,
+        peer_id: Uuid,
+        mut entry: EntryInfo,
+    ) -> io::Result<Option<EntryInfo>> {
+        let pv = entry.version.get(&peer_id).copied().unwrap_or(0);
+        if pv > MAX_TRUSTED_COUNTER {
+            warn!(
+                entry = %entry.name,
+                peer = %peer_id,
+                counter = pv,
+                "rejecting poisoned peer version counter on inbound entry"
+            );
+            return Ok(None);
+        }
+        entry.version = HashMap::from([(peer_id, pv)]);
+        entry.version.entry(self.state.local_id()).or_insert(0);
+        trace!(entry = %entry.name, peer = %peer_id, "inserting peer entry");
+        self.db.insert_or_replace_entry(&entry).await?;
+        Ok(Some(entry))
+    }
+
     pub async fn entry_created(
         &self,
         name: &RelativePath,

--- a/app/src/application/state/entry_manager.rs
+++ b/app/src/application/state/entry_manager.rs
@@ -245,21 +245,16 @@ impl<P: PersistenceInterface> EntryManager<P> {
         peer_id: Uuid,
         mut entry: EntryInfo,
     ) -> io::Result<Option<EntryInfo>> {
-        let pv = entry.version.get(&peer_id).copied().unwrap_or(0);
-        if pv > MAX_TRUSTED_COUNTER {
-            warn!(
-                entry = %entry.name,
-                peer = %peer_id,
-                counter = pv,
-                "rejecting poisoned peer version counter on inbound entry"
-            );
+        let Some(sanitized) = Self::sanitize_peer_entry(peer_id, &entry) else {
             return Ok(None);
-        }
+        };
+
         let mut version = self
             .get_entry(&entry.name)
             .await?
             .map(|stored| stored.version)
             .unwrap_or_default();
+        let pv = sanitized.version.get(&peer_id).copied().unwrap_or(0);
         let peer_version = version.entry(peer_id).or_insert(0);
         *peer_version = (*peer_version).max(pv);
         version.entry(self.state.local_id()).or_insert(0);
@@ -320,6 +315,10 @@ impl<P: PersistenceInterface> EntryManager<P> {
             }
 
             if dirs.contains_key(&peer_entry.get_sync_dir()) {
+                let Some(peer_entry) = Self::sanitize_peer_entry(peer.id, &peer_entry) else {
+                    continue;
+                };
+
                 if let Some(mut local_entry) = self.get_entry(&name).await? {
                     let cmp = self
                         .compare_and_resolve_conflict(&mut local_entry, &peer_entry, peer.id)
@@ -441,13 +440,38 @@ impl<P: PersistenceInterface> EntryManager<P> {
             return Ok(VersionCmp::KeepSelf);
         }
 
+        let Some(peer_entry) = Self::sanitize_peer_entry(peer_id, peer_entry) else {
+            return Ok(VersionCmp::KeepSelf);
+        };
+
         match self.get_entry(&peer_entry.name).await? {
             Some(mut local_entry) => {
-                self.compare_and_resolve_conflict(&mut local_entry, peer_entry, peer_id)
+                self.compare_and_resolve_conflict(&mut local_entry, &peer_entry, peer_id)
                     .await
             }
             None => Ok(VersionCmp::KeepOther),
         }
+    }
+
+    fn sanitize_peer_entry(peer_id: Uuid, entry: &EntryInfo) -> Option<EntryInfo> {
+        let pv = entry.version.get(&peer_id).copied().unwrap_or(0);
+        if pv > MAX_TRUSTED_COUNTER {
+            warn!(
+                entry = %entry.name,
+                peer = %peer_id,
+                counter = pv,
+                "rejecting poisoned peer version counter"
+            );
+            return None;
+        }
+
+        let mut sanitized = entry.clone();
+        sanitized.version = entry
+            .version
+            .get(&peer_id)
+            .map(|pv| HashMap::from([(peer_id, *pv)]))
+            .unwrap_or_default();
+        Some(sanitized)
     }
 
     /// Merges the peer's version counter for **its own axis** into
@@ -682,6 +706,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_entries_to_request_ignores_foreign_axes_before_compare() {
+        let (_env, _temp_dir, sync_dir, manager) = setup().await;
+        let sync_root = add_sync_dir(&manager, &sync_dir).await;
+        let local_id = manager.state.local_id();
+        let peer_id = Uuid::new_v4();
+        let peer = Peer::new(
+            peer_id,
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            "peer".to_string(),
+            Uuid::new_v4(),
+            vec![SyncDirectory {
+                name: sync_root.clone(),
+            }],
+        );
+        let name = dir_relative(&sync_root, "notes.txt");
+
+        manager
+            .insert_entry(EntryInfo {
+                name: name.clone(),
+                kind: EntryKind::File,
+                hash: Some("local-hash".into()),
+                version: HashMap::from([(local_id, 2), (peer_id, 1)]),
+            })
+            .await
+            .unwrap();
+
+        let peer_entry = EntryInfo {
+            name: name.clone(),
+            kind: EntryKind::File,
+            hash: Some("peer-hash".into()),
+            version: HashMap::from([(local_id, 99), (peer_id, 1)]),
+        };
+
+        let entries = manager
+            .get_entries_to_request(&peer, HashMap::from([(name, peer_entry)]))
+            .await
+            .unwrap();
+
+        assert!(
+            entries.is_empty(),
+            "foreign local-axis claim must not make peer entry win"
+        );
+    }
+
+    #[tokio::test]
     async fn handle_metadata_ignores_git_peer_entries() {
         let (_env, _temp_dir, sync_dir, manager) = setup().await;
         let sync_root = add_sync_dir(&manager, &sync_dir).await;
@@ -901,6 +970,37 @@ mod tests {
         assert!(matches!(cmp, VersionCmp::KeepSelf));
     }
 
+    #[tokio::test]
+    async fn handle_metadata_ignores_foreign_axes_before_compare() {
+        let (_env, _temp_dir, sync_dir, manager) = setup().await;
+        let sync_root = add_sync_dir(&manager, &sync_dir).await;
+        let local_id = manager.state.local_id();
+        let peer_id = Uuid::new_v4();
+        let name = dir_relative(&sync_root, "doc.txt");
+
+        manager
+            .insert_entry(EntryInfo {
+                name: name.clone(),
+                kind: EntryKind::File,
+                hash: Some("local-hash".into()),
+                version: HashMap::from([(local_id, 2), (peer_id, 1)]),
+            })
+            .await
+            .unwrap();
+
+        let peer_entry = EntryInfo {
+            name,
+            kind: EntryKind::File,
+            hash: Some("peer-hash".into()),
+            // This would force KeepOther if compared before sanitizing.
+            version: HashMap::from([(local_id, 99), (peer_id, 1)]),
+        };
+
+        let cmp = manager.handle_metadata(peer_id, &peer_entry).await.unwrap();
+
+        assert!(matches!(cmp, VersionCmp::KeepSelf));
+    }
+
     /// After a non-conflict handle_metadata, only the peer's own axis
     /// (`peer_entry.version[peer_id]`) is merged into the local vector.
     /// Foreign axes the peer claims to know about are ignored, because
@@ -975,9 +1075,9 @@ mod tests {
             version: HashMap::from([(peer_id, u64::MAX)]),
         };
 
-        // Equal kind + hash + dominated local axis means handle_metadata
-        // would normally try to merge — the poisoned counter must abort
-        // that merge cleanly rather than persist `u64::MAX`.
+        // Equal kind + hash would normally converge metadata, but the
+        // poisoned sender-owned counter must be dropped before compare
+        // or persistence can write `u64::MAX`.
         manager.handle_metadata(peer_id, &peer_entry).await.unwrap();
 
         let stored = manager.get_entry(&name).await.unwrap().unwrap();

--- a/app/src/application/state/entry_manager.rs
+++ b/app/src/application/state/entry_manager.rs
@@ -232,6 +232,15 @@ impl<P: PersistenceInterface> EntryManager<P> {
     /// directory-create boundary so a peer cannot poison foreign axes
     /// or write `u64::MAX` counters into the DB on initial sync.
     ///
+    /// Contract: **first-sight callers only.** The persisted vector is
+    /// rebuilt as `{peer_id: pv, local_id: 0}`, which unconditionally
+    /// resets the local axis. Safe for `handle_transfer` /
+    /// `create_received_dir` (the row is new, or its existing local
+    /// counter has already been incorporated into the version
+    /// comparison that decided to accept the peer's copy). Do **not**
+    /// call this on a path where a non-zero local axis still needs to
+    /// be preserved — go through `merge_versions_and_insert` instead.
+    ///
     /// Returns `Ok(None)` if the entry was dropped (warn-and-drop),
     /// `Ok(Some(entry))` after a successful persist.
     pub async fn insert_peer_entry(

--- a/app/src/domain/entry/mod.rs
+++ b/app/src/domain/entry/mod.rs
@@ -3,5 +3,6 @@ pub mod version;
 
 pub use info::EntryInfo;
 pub use info::EntryKind;
+pub use version::MAX_TRUSTED_COUNTER;
 pub use version::VersionCmp;
 pub use version::VersionVector;

--- a/app/src/domain/entry/version.rs
+++ b/app/src/domain/entry/version.rs
@@ -8,6 +8,15 @@ use uuid::Uuid;
 /// change. Two versions are comparable per `EntryInfo::compare`.
 pub type VersionVector = HashMap<Uuid, u64>;
 
+/// Upper bound on a peer-supplied version counter that we'll merge.
+///
+/// Honest counters bump by one per local edit, so they grow slowly.
+/// A peer advertising anything past half of `u64::MAX` is either
+/// broken or hostile, so the merge boundary rejects it rather than
+/// poisoning our state. Half-range leaves plenty of headroom for the
+/// `checked_add` paths in `EntryManager`.
+pub const MAX_TRUSTED_COUNTER: u64 = u64::MAX / 2;
+
 /// The outcome of comparing two `EntryInfo` version vectors.
 ///
 /// `Conflict` is not an error condition — it means the two sides have

--- a/app/src/domain/mod.rs
+++ b/app/src/domain/mod.rs
@@ -15,6 +15,7 @@ pub use chan::MutexChannel;
 pub use directory::SyncDirectory;
 pub use entry::EntryInfo;
 pub use entry::EntryKind;
+pub use entry::MAX_TRUSTED_COUNTER;
 pub use entry::VersionCmp;
 pub use entry::VersionVector;
 pub use fs::CanonicalPath;

--- a/app/src/infra/network/tcp/adapter.rs
+++ b/app/src/infra/network/tcp/adapter.rs
@@ -136,7 +136,7 @@ mod tests {
 
     #[tokio::test]
     async fn recv_ignores_corrupt_transfer_and_keeps_listening() {
-        let env = crate::utils::test_support::test_env().await;
+        let env = crate::utils::test_support::test_env_with_dirs(&["bad"]).await;
         let adapter = TcpAdapter::new(env.state.clone()).await;
         let addr = adapter.listener.local_addr().unwrap();
         let source_id = Uuid::new_v4();

--- a/app/src/infra/network/tcp/chunk.rs
+++ b/app/src/infra/network/tcp/chunk.rs
@@ -1,2 +1,12 @@
 pub(super) const TRANSFER_CHUNK_SIZE: usize = 1024 * 1024;
 pub(super) const MAX_TRANSFER_SIZE: u64 = 16 * 1024 * 1024 * 1024;
+
+/// Upper bound on a handshake JSON payload length advertised by a peer.
+/// Handshakes carry the full entry map, so the cap is generous, but a
+/// `u32` length field with no ceiling lets any LAN host force a ~4 GiB
+/// allocation per connection.
+pub(super) const MAX_HANDSHAKE_JSON_SIZE: usize = 8 * 1024 * 1024;
+
+/// Upper bound on a single `EntryInfo` JSON payload length advertised
+/// by a peer. One entry should be well under 64 KiB.
+pub(super) const MAX_ENTRY_JSON_SIZE: usize = 64 * 1024;

--- a/app/src/infra/network/tcp/receiver.rs
+++ b/app/src/infra/network/tcp/receiver.rs
@@ -6,7 +6,9 @@ use crate::{
         TransportData,
     },
     infra::network::tcp::{
-        chunk::{MAX_TRANSFER_SIZE, TRANSFER_CHUNK_SIZE},
+        chunk::{
+            MAX_ENTRY_JSON_SIZE, MAX_HANDSHAKE_JSON_SIZE, MAX_TRANSFER_SIZE, TRANSFER_CHUNK_SIZE,
+        },
         kind::TcpStreamKind,
     },
     utils::fs::is_git_path,
@@ -66,6 +68,12 @@ impl TcpReceiver {
         let mut len_buf = [0u8; 4];
         stream.read_exact(&mut len_buf).await?;
         let len = u32::from_be_bytes(len_buf) as usize;
+
+        if len > MAX_HANDSHAKE_JSON_SIZE {
+            return Err(TransportError::new(&format!(
+                "Handshake JSON size {len} exceeds MAX_HANDSHAKE_JSON_SIZE {MAX_HANDSHAKE_JSON_SIZE}",
+            )));
+        }
 
         let mut buf = vec![0u8; len];
         stream.read_exact(&mut buf).await?;
@@ -173,6 +181,12 @@ impl TcpReceiver {
         let mut json_len_buf = [0u8; 4];
         stream.read_exact(&mut json_len_buf).await?;
         let json_len = u32::from_be_bytes(json_len_buf) as usize;
+
+        if json_len > MAX_ENTRY_JSON_SIZE {
+            return Err(TransportError::new(&format!(
+                "Entry JSON size {json_len} exceeds MAX_ENTRY_JSON_SIZE {MAX_ENTRY_JSON_SIZE}",
+            )));
+        }
 
         let mut json_buf = vec![0u8; json_len];
         stream.read_exact(&mut json_buf).await?;
@@ -634,6 +648,67 @@ mod tests {
         let root_path = state.home_path().join(&root);
         if root_path.exists() {
             fs::remove_dir_all(root_path).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn read_handshake_rejects_oversized_advertised_length() {
+        let env = crate::utils::test_support::test_env().await;
+        let state = env.state.clone();
+        let oversized = (MAX_HANDSHAKE_JSON_SIZE + 1) as u32;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let writer = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            // Only the length prefix is sent — the receiver must
+            // reject before allocating, so no JSON body follows.
+            stream.write_all(&oversized.to_be_bytes()).await.unwrap();
+        });
+
+        let (stream, _) = listener.accept().await.unwrap();
+        let receiver = TcpReceiver::new(state.clone());
+        let result = receiver
+            .read_data(stream, TcpStreamKind::HandshakeSyn, Uuid::new_v4())
+            .await;
+        writer.await.unwrap();
+
+        match result {
+            Err(TransportError::Failure(m)) => {
+                assert!(
+                    m.contains("MAX_HANDSHAKE_JSON_SIZE"),
+                    "unexpected error: {m}"
+                )
+            }
+            Ok(_) => panic!("expected oversize rejection"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_entry_info_rejects_oversized_advertised_length() {
+        let env = crate::utils::test_support::test_env().await;
+        let state = env.state.clone();
+        let oversized = (MAX_ENTRY_JSON_SIZE + 1) as u32;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let writer = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream.write_all(&oversized.to_be_bytes()).await.unwrap();
+        });
+
+        let (stream, _) = listener.accept().await.unwrap();
+        let receiver = TcpReceiver::new(state.clone());
+        let result = receiver
+            .read_data(stream, TcpStreamKind::Metadata, Uuid::new_v4())
+            .await;
+        writer.await.unwrap();
+
+        match result {
+            Err(TransportError::Failure(m)) => {
+                assert!(m.contains("MAX_ENTRY_JSON_SIZE"), "unexpected error: {m}")
+            }
+            Ok(_) => panic!("expected oversize rejection"),
         }
     }
 }

--- a/app/src/infra/network/tcp/receiver.rs
+++ b/app/src/infra/network/tcp/receiver.rs
@@ -2,8 +2,8 @@ use crate::{
     application::AppState,
     application::network::transport::interface::{TransportError, TransportResult},
     domain::{
-        EntryInfo, EntryKind, HandshakeData, RelativePath, ServerEvent, SyncDirectory,
-        TransportData,
+        EntryInfo, EntryKind, HandshakeData, MAX_TRUSTED_COUNTER, RelativePath, ServerEvent,
+        SyncDirectory, TransportData,
     },
     infra::network::tcp::{
         chunk::{
@@ -110,7 +110,10 @@ impl TcpReceiver {
         // Header parsed — any failure from here on can be attributed to this
         // specific entry, so emit `EntrySyncFailed` before propagating the
         // error (the adapter then swallows the error itself).
-        match self.read_transfer_after_header(stream, &entry).await {
+        match self
+            .read_transfer_after_header(stream, &entry, source_id)
+            .await
+        {
             Ok(()) => Ok(TransportData::Transfer(entry)),
             Err(err) => {
                 self.broadcast_sync_failed(source_id, &entry, &err);
@@ -123,6 +126,7 @@ impl TcpReceiver {
         &self,
         stream: &mut TcpStream,
         entry: &EntryInfo,
+        source_id: Uuid,
     ) -> TransportResult<()> {
         let mut entry_size_buf = [0u8; 8];
         stream.read_exact(&mut entry_size_buf).await?;
@@ -134,7 +138,10 @@ impl TcpReceiver {
             )));
         }
 
-        if is_git_path(&entry.name) {
+        if self
+            .should_drop_transfer_before_disk_write(entry, source_id)
+            .await
+        {
             // Drain the payload from the wire without writing to disk.
             Self::discard_bytes(stream, entry_size, TRANSFER_CHUNK_SIZE).await?;
             return Ok(());
@@ -165,6 +172,21 @@ impl TcpReceiver {
         }
 
         self.finalise_staging(entry, staging).await
+    }
+
+    async fn should_drop_transfer_before_disk_write(
+        &self,
+        entry: &EntryInfo,
+        source_id: Uuid,
+    ) -> bool {
+        if is_git_path(&entry.name) || !self.state.contains_sync_dir(&entry.get_sync_dir()).await {
+            return true;
+        }
+
+        entry
+            .version
+            .get(&source_id)
+            .is_some_and(|counter| *counter > MAX_TRUSTED_COUNTER)
     }
 
     fn broadcast_sync_failed(&self, peer: Uuid, entry: &EntryInfo, err: &TransportError) {
@@ -474,10 +496,10 @@ mod tests {
 
     #[tokio::test]
     async fn read_transfer_streams_file_to_home_and_validates_hash() {
-        let env = crate::utils::test_support::test_env().await;
+        let env = crate::utils::test_support::test_env_with_dirs(&["sync"]).await;
         let state = env.state.clone();
         let root = format!("tcp_chunk_ok_{}", Uuid::new_v4());
-        let entry_name = format!("{root}/payload.bin");
+        let entry_name = format!("sync/{root}/payload.bin");
         let original_path = state.home_path().join(&entry_name);
         let contents: Vec<u8> = (0..200u32).map(|i| (i % 256) as u8).collect();
         let hash = format!("{:x}", Sha256::digest(&contents));
@@ -504,17 +526,17 @@ mod tests {
         let on_disk = fs::read(&original_path).await.unwrap();
         assert_eq!(on_disk, contents);
 
-        let root_path = state.home_path().join(&root);
+        let root_path = state.home_path().join(format!("sync/{root}"));
         fs::remove_dir_all(root_path).await.unwrap();
     }
 
     #[tokio::test]
     async fn read_transfer_rejects_hash_mismatch_and_cleans_staging() {
-        let env = crate::utils::test_support::test_env().await;
+        let env = crate::utils::test_support::test_env_with_dirs(&["sync"]).await;
         let state = env.state.clone();
         let mut sse_rx = state.sse_subscribe();
         let root = format!("tcp_chunk_bad_{}", Uuid::new_v4());
-        let entry_name = format!("{root}/payload.bin");
+        let entry_name = format!("sync/{root}/payload.bin");
         let original_path = state.home_path().join(&entry_name);
         let contents = vec![0xAAu8; 64];
         let entry = file_entry(&entry_name, Some("deadbeef".to_string()));
@@ -558,7 +580,7 @@ mod tests {
             other => panic!("unexpected event: {other:?}"),
         }
 
-        let root_path = state.home_path().join(&root);
+        let root_path = state.home_path().join(format!("sync/{root}"));
         if root_path.exists() {
             fs::remove_dir_all(root_path).await.unwrap();
         }
@@ -649,6 +671,78 @@ mod tests {
         if root_path.exists() {
             fs::remove_dir_all(root_path).await.unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn read_transfer_outside_configured_sync_dir_never_writes_to_home() {
+        let env = crate::utils::test_support::test_env_with_dirs(&["sync"]).await;
+        let state = env.state.clone();
+        let entry_name = "other/payload.bin";
+        let original_path = state.home_path().join(entry_name);
+        let contents = b"outside configured sync dir".to_vec();
+        let hash = format!("{:x}", Sha256::digest(&contents));
+        let entry = file_entry(entry_name, Some(hash));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let entry_clone = entry.clone();
+        let contents_clone = contents.clone();
+        let writer = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            write_transfer_to_stream(&mut stream, &entry_clone, &contents_clone).await;
+        });
+
+        let (stream, _) = listener.accept().await.unwrap();
+        let receiver = TcpReceiver::new(state.clone());
+        let data = ok(receiver
+            .read_data(stream, TcpStreamKind::Transfer, Uuid::new_v4())
+            .await);
+        writer.await.unwrap();
+
+        assert!(matches!(data, TransportData::Transfer(_)));
+        assert!(!original_path.exists());
+        assert!(!state.home_path().join("other").exists());
+    }
+
+    #[tokio::test]
+    async fn read_transfer_with_poisoned_peer_counter_never_overwrites_home() {
+        let env = crate::utils::test_support::test_env_with_dirs(&["sync"]).await;
+        let state = env.state.clone();
+        let peer = Uuid::new_v4();
+        let entry_name = "sync/payload.bin";
+        let original_path = state.home_path().join(entry_name);
+        fs::create_dir_all(original_path.parent().unwrap())
+            .await
+            .unwrap();
+        fs::write(&original_path, b"original").await.unwrap();
+
+        let contents = b"poisoned payload".to_vec();
+        let hash = format!("{:x}", Sha256::digest(&contents));
+        let entry = EntryInfo {
+            name: entry_name.into(),
+            kind: EntryKind::File,
+            hash: Some(hash),
+            version: HashMap::from([(peer, u64::MAX)]),
+        };
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let entry_clone = entry.clone();
+        let contents_clone = contents.clone();
+        let writer = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            write_transfer_to_stream(&mut stream, &entry_clone, &contents_clone).await;
+        });
+
+        let (stream, _) = listener.accept().await.unwrap();
+        let receiver = TcpReceiver::new(state.clone());
+        let data = ok(receiver
+            .read_data(stream, TcpStreamKind::Transfer, peer)
+            .await);
+        writer.await.unwrap();
+
+        assert!(matches!(data, TransportData::Transfer(_)));
+        assert_eq!(fs::read(&original_path).await.unwrap(), b"original");
     }
 
     #[tokio::test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,6 +110,8 @@ Deleted entries are not removed from the metadata store.  Instead, their `hash` 
 
 When a peer report arrives, only the peer's **own axis** (`peer_entry.version[peer_id]`) is merged into the local vector.  Foreign axes the peer claims to know about are dropped, because an unauthenticated peer can advertise arbitrary values for other devices' counters and poison their meaning.  Our copy of device B's counter only updates when we receive a message directly from B.  Counters above `MAX_TRUSTED_COUNTER` (`u64::MAX / 2`) are rejected as poisoned; the merge is skipped rather than persisted.
 
+The same rule applies on the first-sight Transfer / directory-create path: `TransportReceiver::handle_transfer` and `create_received_dir` go through `EntryManager::insert_peer_entry`, which strips foreign axes and rejects poisoned counters before persisting.  Plain `insert_entry` is reserved for trusted local writes.
+
 Local counter increments (`entry_modified`, `delete_and_update_entry`, `build_db`) use `checked_add`, so an overflow returns an `io::Error` instead of wrapping silently.
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,7 +110,7 @@ Deleted entries are not removed from the metadata store.  Instead, their `hash` 
 
 When a peer report arrives, only the peer's **own axis** (`peer_entry.version[peer_id]`) is merged into the local vector.  Foreign axes the peer claims to know about are dropped, because an unauthenticated peer can advertise arbitrary values for other devices' counters and poison their meaning.  Our copy of device B's counter only updates when we receive a message directly from B.  Counters above `MAX_TRUSTED_COUNTER` (`u64::MAX / 2`) are rejected as poisoned; the merge is skipped rather than persisted.
 
-The same rule applies on the first-sight Transfer / directory-create path: `TransportReceiver::handle_transfer` and `create_received_dir` go through `EntryManager::insert_peer_entry`, which strips foreign axes and rejects poisoned counters before persisting.  Plain `insert_entry` is reserved for trusted local writes.
+The same rule applies on the first-sight Transfer / directory-create path: `TransportReceiver::handle_transfer` and `create_received_dir` go through `EntryManager::insert_peer_entry`, which strips foreign axes and rejects poisoned counters before persisting.  `TcpReceiver` also rejects or drain-and-drops poisoned `Transfer` frames before staging bytes, because the TCP adapter materializes file payloads before metadata persistence.  Plain `insert_entry` is reserved for trusted local writes.
 
 Local counter increments (`entry_modified`, `delete_and_update_entry`, `build_db`) use `checked_add`, so an overflow returns an `io::Error` instead of wrapping silently.
 
@@ -196,7 +196,7 @@ Every inbound entry boundary applies two co-located filters before any DB mutati
 1. The path component check `is_git_path` (`.git/` is always excluded).
 2. The configured-sync-dir check `AppState::contains_sync_dir(entry.get_sync_dir())`.
 
-This applies in `TransportReceiver::handle_metadata`, `handle_request`, and `handle_transfer`, mirroring the check already in `get_entries_to_request` and `build_db`.  A peer cannot push or pull entries that resolve to a sync directory the local user has not opted in to.
+This applies in `TransportReceiver::handle_metadata`, `handle_request`, and `handle_transfer`, mirroring the check already in `get_entries_to_request` and `build_db`.  For `Transfer` frames, `TcpReceiver` applies the configured-sync-dir check before staging or finalizing bytes, because application-layer handling happens after the adapter decodes the frame.  A peer cannot push or pull entries that resolve to a sync directory the local user has not opted in to.
 
 `RelativePath::starts_with_dir` is used everywhere a "is path under directory X" check is needed, including `AppState::is_under_sync_dir`, so a configured directory `foo` never matches a sibling path like `foobar/file.txt`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,6 +106,12 @@ This naming ensures no data is lost and the conflict file is unambiguously assoc
 
 Deleted entries are not removed from the metadata store.  Instead, their `hash` field is set to the 32-character all-zeros string `"00000000000000000000000000000000"` (`REMOVED_HASH`).  This sentinel allows the version vector to keep propagating the deletion to peers that missed it.
 
+### Merging peer version vectors
+
+When a peer report arrives, only the peer's **own axis** (`peer_entry.version[peer_id]`) is merged into the local vector.  Foreign axes the peer claims to know about are dropped, because an unauthenticated peer can advertise arbitrary values for other devices' counters and poison their meaning.  Our copy of device B's counter only updates when we receive a message directly from B.  Counters above `MAX_TRUSTED_COUNTER` (`u64::MAX / 2`) are rejected as poisoned; the merge is skipped rather than persisted.
+
+Local counter increments (`entry_modified`, `delete_and_update_entry`, `build_db`) use `checked_add`, so an overflow returns an `io::Error` instead of wrapping silently.
+
 ---
 
 ## TCP Wire Format
@@ -168,6 +174,33 @@ Both use the short frame (no file bytes):
 `Transfer` frames stream file bytes in **1 MiB chunks** (constant `TRANSFER_CHUNK_SIZE = 1024 * 1024`) with a streaming SHA-256 computed over the bytes actually sent.  The maximum supported transfer size is **16 GiB** (`MAX_TRANSFER_SIZE = 16 * 1024 * 1024 * 1024`).
 
 If the source file shrinks during streaming the remaining bytes are zero-padded so the wire size matches the advertised `S`.  The hash will diverge and the receiver rejects the transfer by hash mismatch.
+
+### Inbound payload size caps
+
+Each variable-length JSON frame has a hard upper bound that is enforced **before** allocating the receive buffer, so a peer that advertises a multi-gigabyte length cannot force an oversized allocation:
+
+| Constant | Value | Applies to |
+|----------|-------|-----------|
+| `MAX_HANDSHAKE_JSON_SIZE` | 8 MiB | `HandshakeSyn` / `HandshakeAck` JSON |
+| `MAX_ENTRY_JSON_SIZE` | 64 KiB | `EntryInfo` JSON in `Metadata` / `Request` / `Transfer` |
+| `MAX_TRANSFER_SIZE` | 16 GiB | The raw file bytes following a `Transfer` header |
+
+Oversized frames are rejected with a `TransportError`; the adapter logs and skips them, the synchronizer keeps running.
+
+### Inbound entry scoping
+
+Every inbound entry boundary applies two co-located filters before any DB mutation or disk write:
+
+1. The path component check `is_git_path` (`.git/` is always excluded).
+2. The configured-sync-dir check `AppState::contains_sync_dir(entry.get_sync_dir())`.
+
+This applies in `TransportReceiver::handle_metadata`, `handle_request`, and `handle_transfer`, mirroring the check already in `get_entries_to_request` and `build_db`.  A peer cannot push or pull entries that resolve to a sync directory the local user has not opted in to.
+
+`RelativePath::starts_with_dir` is used everywhere a "is path under directory X" check is needed, including `AppState::is_under_sync_dir`, so a configured directory `foo` never matches a sibling path like `foobar/file.txt`.
+
+### Peer identity (deferred)
+
+The `source_id` field on the wire frame is currently **trusted as advertised** — there is no cryptographic identity behind it.  Mutual TLS with per-device certificates (or a Noise IK handshake) is tracked as a separate follow-up to issue #32; until that lands, treat Synche as safe to run on a trusted LAN only.
 
 ### Error handling
 


### PR DESCRIPTION
Closes #32 (auth-only finding moved to #36).

Addresses 5 of the 6 findings in #32:

- Scope inbound Metadata / Request / Transfer to configured sync_dirs.
- Cap handshake JSON (8 MiB) and entry JSON (64 KiB) before allocating.
- Merge only the peer's own axis from inbound version vectors; reject counters > `u64::MAX / 2`.
- `checked_add` on all local version-counter increments.
- `RelativePath::starts_with_dir` for `AppState::is_under_sync_dir` (no more `foo`/`foobar` collisions).

mTLS / Noise IK identity authentication is tracked separately in #36.

**Behavior change worth noting:** foreign version axes from peer reports are no longer merged. Our copy of device B's counter only updates when we receive directly from B. In a 3+ peer mesh convergence is slower than before, but immune to axis poisoning.