### PR TITLE
fix: conflict-file filename collisions overwrite prior copies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ TCP transport receive errors after a connection is accepted are treated as bad p
 
 `VersionVector = HashMap<Uuid, u64>` keyed by device `local_id` (`app/src/domain/entry/version.rs`). Comparing two versions yields `VersionCmp::{Equal, KeepSelf, KeepOther, Conflict}` — concurrent edits produce `Conflict` (which the system materializes as a conflict file) rather than overwriting. Anything that mutates `EntryInfo` or decides which side wins must go through this comparison.
 
+`EntryManager::handle_conflict` writes the losing local file aside as `<stem>_CONFLICT_<unix_ms>_<device_uuid>_<random>.<ext>` and **must** use `fs::OpenOptions::create_new(true)` (never `fs::copy`, which truncates), retrying with a fresh random suffix on `AlreadyExists`. Millisecond resolution alone is not collision-proof — the per-attempt random component is what guarantees two conflicts for the same file in the same second from the same peer don't overwrite each other; the conflict-recovery path itself must not lose data (issue #41 B6). Conflict copies still re-enter sync and propagate to peers like any other new file.
+
 ### Permanent exclusions
 
 Permanent path exclusions must be enforced at every boundary where entries can enter or leave sync: filesystem scans, watcher events, handshakes, metadata handling, request handling, transfer handling, and disk writes. Use `utils::fs::is_git_path` as the shared predicate for `.git/` path exclusion. It matches an exact `.git` path component only, so `.gitignore`, `.gitattributes`, `.github/`, and `foo.git/` remain syncable.

--- a/app/src/application/state/entry_manager.rs
+++ b/app/src/application/state/entry_manager.rs
@@ -472,20 +472,42 @@ impl<P: PersistenceInterface> EntryManager<P> {
         let stem = path.file_stem().unwrap_or_default().to_string_lossy();
         let ext = path.extension().unwrap_or_default().to_string_lossy();
 
-        let now = SystemTime::now()
+        // Issue #41 (B6): millisecond resolution plus a fresh random
+        // component per attempt makes filename collisions practically
+        // impossible even for two conflicts in the same second from the
+        // same peer, and `create_new` guarantees we never truncate an
+        // existing conflict copy — the conflict-recovery path must not
+        // itself lose data.
+        let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
-            .as_secs();
+            .as_millis();
+        let device = self.state.local_id();
 
-        let new_path = path.with_file_name(format!(
-            "{}_CONFLICT_{}_{}.{}",
-            stem,
-            now,
-            self.state.local_id(),
-            ext
-        ));
+        loop {
+            let rand = &Uuid::new_v4().simple().to_string()[..8];
+            let file_name = if ext.is_empty() {
+                format!("{stem}_CONFLICT_{now_ms}_{device}_{rand}")
+            } else {
+                format!("{stem}_CONFLICT_{now_ms}_{device}_{rand}.{ext}")
+            };
+            let new_path = path.with_file_name(file_name);
 
-        fs::copy(path, new_path).await?;
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&new_path)
+                .await
+            {
+                Ok(mut dest) => {
+                    let mut src = fs::File::open(&path).await?;
+                    io::copy(&mut src, &mut dest).await?;
+                    break;
+                }
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(e) => return Err(e),
+            }
+        }
 
         Ok(VersionCmp::KeepOther)
     }
@@ -1130,6 +1152,58 @@ mod tests {
         assert!(
             siblings.iter().any(|n| n.contains("_CONFLICT_")),
             "expected a _CONFLICT_ file in {sync_dir:?}, found: {siblings:?}",
+        );
+    }
+
+    // Issue #41 (B6): two conflicts for the same file in quick
+    // succession must each produce a distinct conflict copy — the
+    // second must never truncate the first.
+    #[tokio::test]
+    async fn handle_conflict_back_to_back_does_not_overwrite_prior_conflict_copy() {
+        let (_env, _temp_dir, sync_dir, manager) = setup().await;
+        let sync_root = add_sync_dir(&manager, &sync_dir).await;
+        // peer_id < any real Uuid::new_v4 so local must give way both times.
+        let peer_id = Uuid::nil();
+
+        let rel: RelativePath = dir_relative(&sync_root, "report.md");
+        let absolute = rel.to_canonical(manager.state.home_path());
+
+        let mut local = EntryInfo {
+            name: rel.clone(),
+            kind: EntryKind::File,
+            hash: Some("local-hash".into()),
+            version: HashMap::from([(manager.state.local_id(), 1)]),
+        };
+        let peer = EntryInfo {
+            name: rel,
+            kind: EntryKind::File,
+            hash: Some("peer-hash".into()),
+            version: HashMap::from([(peer_id, 1)]),
+        };
+
+        fs::write(&absolute, b"v1").unwrap();
+        manager
+            .handle_conflict(&mut local, &peer, peer_id)
+            .await
+            .unwrap();
+
+        fs::write(&absolute, b"v2").unwrap();
+        manager
+            .handle_conflict(&mut local, &peer, peer_id)
+            .await
+            .unwrap();
+
+        let conflict_contents: std::collections::HashSet<String> = fs::read_dir(&sync_dir)
+            .unwrap()
+            .map(|e| e.unwrap())
+            .filter(|e| e.file_name().to_string_lossy().contains("_CONFLICT_"))
+            .map(|e| fs::read_to_string(e.path()).unwrap())
+            .collect();
+
+        assert_eq!(
+            conflict_contents,
+            std::collections::HashSet::from(["v1".to_string(), "v2".to_string()]),
+            "both conflict copies must survive; found: {conflict_contents:?}",
         );
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,12 +95,12 @@ The comparison iterates over the union of all device keys in both vectors.  If l
 **Conflict file naming:**
 
 ```
-<stem>_CONFLICT_<unix_epoch_seconds>_<device_uuid>.<ext>
+<stem>_CONFLICT_<unix_epoch_millis>_<device_uuid>_<random>.<ext>
 ```
 
-Example: `report_CONFLICT_1716864000_a1b2c3d4-e5f6-47g8-h9i0-j1k2l3m4n5o6.md`
+Example: `report_CONFLICT_1716864000123_a1b2c3d4-e5f6-47g8-h9i0-j1k2l3m4n5o6_9f3c1ab7.md`
 
-This naming ensures no data is lost and the conflict file is unambiguously associated with the device that created it.
+The copy is written with `create_new` (never truncating an existing file) and retried with a fresh random suffix on the rare name collision.  Millisecond resolution plus the random component means two conflicts for the same file within the same second from the same peer no longer collide, so the conflict-recovery path itself cannot lose data (issue #41 B6).  The device UUID keeps the copy unambiguously associated with the device that created it.
 
 ### Conflict-resolved-as-KeepSelf never merges the peer's axis
 


### PR DESCRIPTION
Closes #41

`handle_conflict` used second-resolution timestamps + a constant device id and `fs::copy` (which truncates), so two conflicts for the same file within one second from the same peer collided and the first conflict copy was lost. Now uses millisecond resolution + a random suffix and reserves the name with `create_new` (retry on `AlreadyExists`), so a conflict copy never overwrites a prior one.