### PR TITLE
release: v0.0.5-alpha + honest UUID-collision handshake guard (#52)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,9 @@ The file watcher does **not** hold the per-entry inflight lock, so a remote-driv
 
 ### Peer identity is currently untrusted
 
-`source_id` on the TCP frame is read off the wire and **not** verified — there is no TLS or signature today. The follow-up tracked under issue #32 will replace this with mutual TLS or Noise IK. Until that lands, any code that decides "is this peer allowed to do X" cannot trust `source_id` for cross-peer authorization — only use it for routing.
+`source_id` on the TCP frame is read off the wire and **not** verified — there is no TLS or signature today. The follow-up tracked under issue #36 will replace this with mutual TLS or Noise IK. Until that lands, any code that decides "is this peer allowed to do X" cannot trust `source_id` for cross-peer authorization — only use it for routing.
+
+As a cheap honest-collision guard (issue #52, split from #36), `TransportReceiver::handle_handshake` rejects any handshake whose `source_id == local_id` and logs loudly: a peer declaring our own device id means a duplicated `device_id` (config copy, restored backup, baked-in container id), and without the guard both sides fall through the `local_id < peer_id` tiebreak in `handle_conflict` and overwrite each other. This guard does **not** defend against a malicious peer forging `source_id` — that still requires the cryptographic identity work in #36.
 
 ### Runtime / data files (not in repo)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,7 +2159,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synche"
-version = "0.0.4-alpha"
+version = "0.0.5-alpha"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synche"
-version = "0.0.4-alpha"
+version = "0.0.5-alpha"
 edition = "2024"
 
 [dependencies]

--- a/app/src/application/network/transport/receiver.rs
+++ b/app/src/application/network/transport/receiver.rs
@@ -121,6 +121,21 @@ impl<T: TransportInterface, P: PersistenceInterface> TransportReceiver<T, P> {
             _ => unreachable!(),
         };
 
+        // Honest UUID-collision guard (was #45 B10, split into #52 from the
+        // crypto-auth work in #36): a peer declaring our own device id means a
+        // duplicated device_id (config copy, restored backup, baked-in container
+        // id). Both sides would fall through the `local_id < peer_id` tiebreak in
+        // `handle_conflict` and overwrite each other. Drop the handshake and log
+        // loudly. NOTE: this does NOT defend against a malicious peer forging
+        // source_id — that needs cryptographic identity (#36).
+        if event.metadata.source_id == self.state.local_id() {
+            warn!(
+                peer = %event.metadata.source_id,
+                "rejecting handshake: peer declares our own device id (duplicated device_id?)"
+            );
+            return Ok(());
+        }
+
         let peer = Peer::new(
             event.metadata.source_id,
             event.metadata.source_ip,
@@ -858,6 +873,38 @@ mod tests {
             }
             _ => panic!("unexpected outbound message"),
         }
+        assert!(matches!(send_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn handle_handshake_rejects_peer_claiming_our_own_device_id() {
+        // Issue #52: a handshake whose source_id equals our own local_id means a
+        // duplicated device_id (config copy / restored backup / baked-in
+        // container id). It must be dropped: no peer registered, no Ack/Request
+        // enqueued, so both sides don't fall through the conflict tiebreak.
+        let (env, receiver, _entry_manager, mut send_rx) = setup().await;
+        let local_id = env.state.local_id();
+
+        let evt = TransportEvent {
+            payload: TransportData::HandshakeSyn(HandshakeData {
+                hostname: "impostor".to_string(),
+                instance_id: Uuid::new_v4(),
+                sync_dirs: Vec::new(),
+                entries: HashMap::new(),
+            }),
+            metadata: TransportMetadata {
+                source_id: local_id,
+                source_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            },
+            staging: None,
+        };
+
+        receiver.handle_handshake(evt).await.unwrap();
+
+        assert!(
+            receiver.peer_manager.list().await.is_empty(),
+            "handshake declaring our own device id must not register a peer"
+        );
         assert!(matches!(send_rx.try_recv(), Err(TryRecvError::Empty)));
     }
 


### PR DESCRIPTION
## Summary

Prepares the `0.0.5-alpha` release of the accumulated #32–#44 sync reliability & security work (46 commits since `v0.0.4-alpha`), and adds one small safety guard that belongs in this release.

### Honest UUID-collision handshake guard (#52)

`TransportReceiver::handle_handshake` now rejects any handshake whose `source_id == local_id` and logs loudly. Two devices can accidentally share a `device_id` (config copy, restored backup, baked-in container id); without the guard both sides fall through the `local_id < peer_id` tiebreak in `handle_conflict` and overwrite each other. This does **not** defend against a malicious peer forging `source_id` — that remains tracked in #36.

- Guard + unit test in `app/src/application/network/transport/receiver.rs`
- `AGENTS.md` "Peer identity is currently untrusted" section updated (and its stale #32 auth reference corrected to #36)

### Version bump

`app/Cargo.toml` `0.0.4-alpha` → `0.0.5-alpha` (single source of truth; surfaces in `main.rs`, root span, GUI footer, `X-Synche-Version` header, `GET /api/info`). `Cargo.lock` refreshed.

## Verification

- `cargo clippy -p synche -- -D warnings` — clean
- `cargo test -p synche` — 216 passed, 0 failed (includes the new `handle_handshake_rejects_peer_claiming_our_own_device_id`)

## Release

After merge, tag `v0.0.5-alpha` on `main` to trigger the `Release` workflow (Linux/macOS/Windows builds + GitHub release).

Closes #52.
