### PR TITLE
Protocol fuzz / malformed-input tests for TCP transport and RelativePath

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ TCP transport receive errors after a connection is accepted are treated as bad p
 
 Permanent path exclusions must be enforced at every boundary where entries can enter or leave sync: filesystem scans, watcher events, handshakes, metadata handling, request handling, transfer handling, and disk writes. Use `utils::fs::is_git_path` as the shared predicate for `.git/` path exclusion. It matches an exact `.git` path component only, so `.gitignore`, `.gitattributes`, `.github/`, and `foo.git/` remain syncable.
 
-Remote transport paths must be validated before any metadata handling or disk write. Use `RelativePath::is_safe_sync_path` to reject absolute paths, parent-directory traversal, empty paths, and backslash-separated paths from peers.
+Remote transport paths must be validated before any metadata handling or disk write. Use `RelativePath::is_safe_sync_path` to reject absolute paths, parent-directory traversal, empty paths, backslash-separated paths, and paths with embedded NUL bytes from peers.
 
 ### Scoping inbound entries to configured sync_dirs
 
@@ -83,6 +83,8 @@ Every inbound `Metadata`/`Request`/`Transfer` handler in `TransportReceiver` (`a
 ### Inbound TCP message size caps
 
 `app/src/infra/network/tcp/chunk.rs` defines three hard caps that are enforced **before** allocating: `MAX_TRANSFER_SIZE` (raw file bytes), `MAX_HANDSHAKE_JSON_SIZE` (handshake JSON), `MAX_ENTRY_JSON_SIZE` (single `EntryInfo` JSON). Anything that decodes a peer-supplied `u32` length must check it against the right cap before `vec![0u8; len]`. Don't add a new variable-length frame without picking (or adding) a cap.
+
+The TCP frame decoder (`receiver.rs`/`adapter.rs`) and `RelativePath::is_safe_sync_path` (`path.rs`) are the wire-facing security edges, so they carry table-driven malformed-input tests (issue #23): oversized/`u32::MAX` length prefixes, streams truncated mid-frame, invalid UTF-8 in string fields, embedded NUL bytes, and unsafe paths (absolute, `..` traversal, backslash/mixed separators). Each case must either be rejected by `is_safe_sync_path`/`validate_*` or drained/dropped by the receiver so the adapter keeps serving other peers. When you add a new frame field or relax a path rule, extend those tables.
 
 ### Sanitizing peer-supplied version vectors
 

--- a/app/src/domain/fs/path.rs
+++ b/app/src/domain/fs/path.rs
@@ -88,6 +88,7 @@ impl RelativePath {
     pub fn is_safe_sync_path(&self) -> bool {
         !self.0.is_empty()
             && !self.0.contains('\\')
+            && !self.0.contains('\0')
             && Path::new(&self.0)
                 .components()
                 .all(|component| matches!(component, Component::Normal(_)))
@@ -137,9 +138,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn relative_path_rejects_paths_that_escape_home() {
-        for path in ["", "/tmp/file", "../file", "sync/../../file", "sync\\file"] {
-            assert!(!RelativePath::from(path).is_safe_sync_path(), "{path}");
+    fn relative_path_rejects_unsafe_sync_paths() {
+        // One representative input per hostile class the protocol decoder
+        // must reject (issue #23): empty, absolute, parent-directory
+        // traversal in several forms, backslash separators, mixed
+        // separators, and embedded NUL bytes.
+        for path in [
+            "",                // empty
+            "/tmp/file",       // absolute
+            "..",              // bare parent
+            "../file",         // leading traversal
+            "../etc/passwd",   // deeper leading traversal
+            "a/../../b",       // interior traversal escaping the root
+            "sync/../../file", // traversal under a sync dir
+            "a\\b\\c",         // backslash-separated
+            "a/b\\c",          // mixed separators
+            "a\0b",            // embedded NUL
+            "sync/\0",         // embedded NUL in a later component
+        ] {
+            assert!(
+                !RelativePath::from(path).is_safe_sync_path(),
+                "expected reject: {path:?}"
+            );
         }
     }
 

--- a/app/src/infra/network/tcp/adapter.rs
+++ b/app/src/infra/network/tcp/adapter.rs
@@ -136,6 +136,54 @@ mod tests {
         }
     }
 
+    async fn write_truncated_metadata(stream: &mut TcpStream, source_id: Uuid) {
+        stream.write_all(source_id.as_bytes()).await.unwrap();
+        stream
+            .write_all(&[TcpStreamKind::Metadata as u8])
+            .await
+            .unwrap();
+        // Advertise 4 KiB of entry JSON but send nothing before closing,
+        // so the decoder hits EOF mid-frame.
+        stream.write_all(&(4096u32).to_be_bytes()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn recv_ignores_truncated_frame_and_keeps_listening() {
+        let env = crate::utils::test_support::test_env_with_dirs(&["ok"]).await;
+        let adapter = TcpAdapter::new(env.state.clone()).await;
+        let addr = adapter.listener.local_addr().unwrap();
+        let source_id = Uuid::new_v4();
+        let metadata_entry = file_entry("ok/payload.bin", "hash");
+
+        let metadata_entry_clone = metadata_entry.clone();
+        let writer = tokio::spawn(async move {
+            let mut bad_stream = TcpStream::connect(addr).await.unwrap();
+            write_truncated_metadata(&mut bad_stream, source_id).await;
+            drop(bad_stream);
+
+            let mut good_stream = TcpStream::connect(addr).await.unwrap();
+            write_metadata(&mut good_stream, source_id, &metadata_entry_clone).await;
+        });
+
+        let result = timeout(Duration::from_secs(2), adapter.recv())
+            .await
+            .expect("adapter should keep listening after truncated frame");
+        writer.await.unwrap();
+
+        let event = match result {
+            Ok(event) => event,
+            Err(TransportError::Failure(message)) => {
+                panic!("unexpected transport error: {message}")
+            }
+        };
+
+        assert_eq!(event.metadata.source_id, source_id);
+        match event.payload {
+            TransportData::Metadata(entry) => assert_eq!(entry.name, metadata_entry.name),
+            _ => panic!("expected metadata after truncated frame"),
+        }
+    }
+
     #[tokio::test]
     async fn recv_ignores_corrupt_transfer_and_keeps_listening() {
         let env = crate::utils::test_support::test_env_with_dirs(&["bad"]).await;

--- a/app/src/infra/network/tcp/receiver.rs
+++ b/app/src/infra/network/tcp/receiver.rs
@@ -410,6 +410,9 @@ mod tests {
             "/tmp/payload.bin",
             "../payload.bin",
             "sync/../../payload.bin",
+            "a\\b\\payload.bin", // backslash-separated
+            "a/b\\payload.bin",  // mixed separators
+            "a\0b.bin",          // embedded NUL
         ] {
             assert_transport_error(
                 TcpReceiver::validate_entry_info(file_entry(path, Some("hash".to_string()))),
@@ -949,5 +952,147 @@ mod tests {
             }
             Ok(_) => panic!("expected oversize rejection"),
         }
+    }
+
+    /// Drive `read_data` against a writer that sends `bytes` then closes the
+    /// connection. Returns the decode result so each malformed-input test can
+    /// assert it was rejected (issue #23).
+    async fn read_data_from_bytes(
+        state: Arc<AppState>,
+        kind: TcpStreamKind,
+        bytes: Vec<u8>,
+    ) -> TransportResult<(TransportData, Option<StagedTransfer>)> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let writer = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream.write_all(&bytes).await.unwrap();
+            // Drop closes the connection, simulating a peer that stops
+            // mid-frame.
+        });
+
+        let (stream, _) = listener.accept().await.unwrap();
+        let receiver = TcpReceiver::new(state);
+        let result = receiver.read_data(stream, kind, Uuid::new_v4()).await;
+        writer.await.unwrap();
+        result
+    }
+
+    #[tokio::test]
+    async fn read_handshake_rejects_truncated_length_prefix() {
+        let env = crate::utils::test_support::test_env().await;
+        // Only two of the four length-prefix bytes before the peer hangs up.
+        let result = read_data_from_bytes(
+            env.state.clone(),
+            TcpStreamKind::HandshakeSyn,
+            vec![0u8, 0u8],
+        )
+        .await;
+        assert!(result.is_err(), "truncated length prefix must be rejected");
+    }
+
+    #[tokio::test]
+    async fn read_handshake_rejects_truncated_body() {
+        let env = crate::utils::test_support::test_env().await;
+        // Advertise 100 bytes of JSON but send only 10 before closing.
+        let mut bytes = (100u32).to_be_bytes().to_vec();
+        bytes.extend_from_slice(&[b'{'; 10]);
+        let result =
+            read_data_from_bytes(env.state.clone(), TcpStreamKind::HandshakeSyn, bytes).await;
+        assert!(result.is_err(), "truncated handshake body must be rejected");
+    }
+
+    #[tokio::test]
+    async fn read_entry_info_rejects_truncated_body() {
+        let env = crate::utils::test_support::test_env().await;
+        // Advertise 50 bytes of entry JSON but send none before closing.
+        let bytes = (50u32).to_be_bytes().to_vec();
+        let result = read_data_from_bytes(env.state.clone(), TcpStreamKind::Metadata, bytes).await;
+        assert!(result.is_err(), "truncated entry body must be rejected");
+    }
+
+    #[tokio::test]
+    async fn read_handshake_rejects_invalid_utf8() {
+        let env = crate::utils::test_support::test_env().await;
+        // Valid 2-byte length prefix, then non-UTF-8 bytes.
+        let mut bytes = (2u32).to_be_bytes().to_vec();
+        bytes.extend_from_slice(&[0xFF, 0xFE]);
+        let result =
+            read_data_from_bytes(env.state.clone(), TcpStreamKind::HandshakeSyn, bytes).await;
+        assert!(result.is_err(), "invalid UTF-8 handshake must be rejected");
+    }
+
+    #[tokio::test]
+    async fn read_entry_info_rejects_invalid_utf8() {
+        let env = crate::utils::test_support::test_env().await;
+        // Valid length prefix, then bytes that are neither UTF-8 nor JSON.
+        let mut bytes = (2u32).to_be_bytes().to_vec();
+        bytes.extend_from_slice(&[0xFF, 0xFE]);
+        let result = read_data_from_bytes(env.state.clone(), TcpStreamKind::Metadata, bytes).await;
+        assert!(result.is_err(), "invalid UTF-8 entry must be rejected");
+    }
+
+    #[tokio::test]
+    async fn read_handshake_rejects_u32_max_length() {
+        let env = crate::utils::test_support::test_env().await;
+        // u32::MAX length prefix with no body: must be rejected by the cap
+        // check before any allocation or further read.
+        let bytes = u32::MAX.to_be_bytes().to_vec();
+        let result =
+            read_data_from_bytes(env.state.clone(), TcpStreamKind::HandshakeSyn, bytes).await;
+        assert_transport_error(result, "MAX_HANDSHAKE_JSON_SIZE");
+    }
+
+    #[tokio::test]
+    async fn read_entry_info_rejects_u32_max_length() {
+        let env = crate::utils::test_support::test_env().await;
+        let bytes = u32::MAX.to_be_bytes().to_vec();
+        let result = read_data_from_bytes(env.state.clone(), TcpStreamKind::Metadata, bytes).await;
+        assert_transport_error(result, "MAX_ENTRY_JSON_SIZE");
+    }
+
+    #[tokio::test]
+    async fn read_transfer_rejects_truncated_payload() {
+        let env = crate::utils::test_support::test_env_with_dirs(&["sync"]).await;
+        let state = env.state.clone();
+        let peer = Uuid::new_v4();
+        let entry_name = format!("sync/truncated-{}.bin", Uuid::new_v4());
+        let original_path = state.home_path().join(&entry_name);
+        let entry = file_entry(&entry_name, Some("ignored".to_string()));
+        state
+            .register_pending_request(peer, entry.name.clone())
+            .await;
+
+        let entry_json = serde_json::to_vec(&entry).unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let writer = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream
+                .write_all(&(entry_json.len() as u32).to_be_bytes())
+                .await
+                .unwrap();
+            stream.write_all(&entry_json).await.unwrap();
+            // Declare 200 payload bytes but send only 20 before closing.
+            stream.write_all(&(200u64).to_be_bytes()).await.unwrap();
+            stream.write_all(&[0u8; 20]).await.unwrap();
+        });
+
+        let (stream, _) = listener.accept().await.unwrap();
+        let receiver = TcpReceiver::new(state.clone());
+        let result = receiver
+            .read_data(stream, TcpStreamKind::Transfer, peer)
+            .await;
+        writer.await.unwrap();
+
+        assert!(result.is_err(), "truncated transfer payload must error");
+        assert!(
+            !original_path.exists(),
+            "truncated transfer must not write to home"
+        );
+        assert!(
+            !state.take_pending_request(peer, &entry.name).await,
+            "failed staging must release the pre-stage claim"
+        );
     }
 }


### PR DESCRIPTION
Closes #23

Table-driven malformed-input tests for the TCP frame decoder and `RelativePath::is_safe_sync_path`: truncated streams, invalid UTF-8, u32::MAX length prefixes, embedded NUL bytes, and unsafe paths. Also hardens `is_safe_sync_path` to reject embedded NUL bytes.